### PR TITLE
Fix for "No such method resolve-selected-child"

### DIFF
--- a/lib/GTK/FlowBox.pm6
+++ b/lib/GTK/FlowBox.pm6
@@ -366,7 +366,7 @@ class GTK::FlowBox is GTK::Container {
   }
 
   method select_child ($child) is also<select-child> {
-    my $to-be-selected = self.resolve-selected-child($child);
+    my $to-be-selected = self!resolve-selected-child($child);
 
     gtk_flow_box_select_child($!fb, $to-be-selected);
   }
@@ -425,7 +425,7 @@ class GTK::FlowBox is GTK::Container {
   method unselect_child (GtkFlowBoxChild() $child)
     is also<unselect-child>
   {
-    my $to-be-unselected = self.resolve-selected-child($child);
+    my $to-be-unselected = self!resolve-selected-child($child);
 
     gtk_flow_box_unselect_child($!fb, $to-be-unselected);
   }

--- a/stats/LastBuildResults-20191118
+++ b/stats/LastBuildResults-20191118
@@ -1,0 +1,23115 @@
+Dependency Generation
+=====================
+real 7.23
+user 8.02
+sys 0.10
+ === Cairo ===
+Stage start      :   0.000
+Stage parse      :   1.143
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.002
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === Data::Dump::Tree ===
+Stage start      :   0.000
+Stage parse      :   1.237
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === Method::Also ===
+Stage start      :   0.000
+Stage parse      :   0.948
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === Pango::AttrList ===
+Stage start      :   0.000
+Stage parse      :   1.437
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === Pango::Context ===
+Stage start      :   0.000
+Stage parse      :   1.624
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.001
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === Pango::FontDescription ===
+Stage start      :   0.000
+Stage parse      :   1.394
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === Pango::FontMap ===
+Stage start      :   0.000
+
+    precomp ../p6-Pango/lib/Pango/FontMap.pm6
+    Stage start      :   0.000
+    
+        precomp ../p6-Pango/lib/Pango/Raw/FontMap.pm6
+        Stage start      :   0.000
+        Stage parse      :   2.052
+        Stage syntaxcheck:   0.000
+        Stage ast        :   0.000
+        Stage optimize   :   0.010
+        Stage mast       :   0.076
+        Stage mbc        :   0.003
+    Stage parse      :   3.895
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.011
+    Stage mast       :   0.057
+    Stage mbc        :   0.002
+Stage parse      :   5.123
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === Pango::Language ===
+Stage start      :   0.000
+
+    precomp ../p6-Pango/lib/Pango/Language.pm6
+    Stage start      :   0.000
+    
+        precomp ../p6-Pango/lib/Pango/Raw/Language.pm6
+        Stage start      :   0.000
+        Stage parse      :   1.730
+        Stage syntaxcheck:   0.000
+        Stage ast        :   0.000
+        Stage optimize   :   0.016
+        Stage mast       :   0.080
+        Stage mbc        :   0.003
+    Stage parse      :   3.466
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.010
+    Stage mast       :   0.055
+    Stage mbc        :   0.003
+Stage parse      :   4.652
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === Pango::Layout ===
+Stage start      :   0.000
+Stage parse      :   1.726
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === Pango::Raw::Types ===
+Stage start      :   0.000
+Stage parse      :   1.038
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.002
+Stage mast       :   0.006
+Stage mbc        :   0.002
+Stage moar       :   0.000
+ === Pango::Tabs ===
+Stage start      :   0.000
+
+    precomp ../p6-Pango/lib/Pango/Tabs.pm6
+    Stage start      :   0.000
+    
+        precomp ../p6-Pango/lib/Pango/Raw/Tabs.pm6
+        Stage start      :   0.000
+        Stage parse      :   1.819
+        Stage syntaxcheck:   0.000
+        Stage ast        :   0.000
+        Stage optimize   :   0.045
+        Stage mast       :   0.070
+        Stage mbc        :   0.003
+    Stage parse      :   3.252
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.087
+    Stage mbc        :   0.007
+Stage parse      :   4.502
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === Pluggable ===
+Stage start      :   0.000
+Stage parse      :   1.150
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ReturnedValue ===
+Stage start      :   0.000
+Stage parse      :   1.000
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Pointers ===
+Stage start      :   0.000
+Stage parse      :   1.201
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Builder::MRO ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/MRO.pm6
+    Stage start      :   0.000
+    Stage parse      :   0.296
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.017
+    Stage mast       :   0.007
+    Stage mbc        :   0.001
+Stage parse      :   1.373
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::Base ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/Base.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.379
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.086
+    Stage mbc        :   0.004
+Stage parse      :   2.554
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::Box ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/Box.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.085
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.012
+    Stage mast       :   0.058
+    Stage mbc        :   0.002
+Stage parse      :   2.209
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::Button ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/Button.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.050
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.008
+    Stage mast       :   0.032
+    Stage mbc        :   0.002
+Stage parse      :   2.156
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::Frame ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/Frame.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.078
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.010
+    Stage mast       :   0.055
+    Stage mbc        :   0.004
+Stage parse      :   2.197
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::Grid ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/Grid.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.116
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.009
+    Stage mast       :   0.062
+    Stage mbc        :   0.003
+Stage parse      :   2.269
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::Image ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/Image.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.035
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.006
+    Stage mast       :   0.029
+    Stage mbc        :   0.001
+Stage parse      :   2.111
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::Label ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/Label.pm6
+    Stage start      :   0.000
+    Stage parse      :   0.997
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.004
+    Stage mast       :   0.028
+    Stage mbc        :   0.001
+Stage parse      :   2.090
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::LinkButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/LinkButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.039
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.014
+    Stage mast       :   0.026
+    Stage mbc        :   0.002
+Stage parse      :   2.125
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::ListBoxRow ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/ListBoxRow.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.022
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.004
+    Stage mast       :   0.028
+    Stage mbc        :   0.001
+Stage parse      :   2.102
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::Menu ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/Menu.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.028
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.005
+    Stage mast       :   0.028
+    Stage mbc        :   0.002
+Stage parse      :   2.115
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::MenuButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/MenuButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.060
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.010
+    Stage mast       :   0.046
+    Stage mbc        :   0.002
+Stage parse      :   2.156
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::MenuItem ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/MenuItem.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.057
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.010
+    Stage mast       :   0.046
+    Stage mbc        :   0.002
+Stage parse      :   2.171
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::MenuShell ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/MenuShell.pm6
+    Stage start      :   0.000
+    Stage parse      :   0.999
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.001
+    Stage mast       :   0.021
+    Stage mbc        :   0.001
+Stage parse      :   2.083
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::Orientable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/Orientable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.041
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.004
+    Stage mast       :   0.029
+    Stage mbc        :   0.001
+Stage parse      :   2.136
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::Revealer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/Revealer.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.081
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.010
+    Stage mast       :   0.059
+    Stage mbc        :   0.004
+Stage parse      :   2.200
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::ToggleButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/ToggleButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.026
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.003
+    Stage mast       :   0.028
+    Stage mbc        :   0.001
+Stage parse      :   2.107
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::Widget ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/Widget.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.005
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.012
+    Stage mast       :   0.051
+    Stage mbc        :   0.002
+Stage parse      :   2.125
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::BuilderWidgets ===
+Stage start      :   0.000
+
+    precomp lib/GTK/BuilderWidgets.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.130
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.064
+    Stage mbc        :   0.004
+Stage parse      :   2.327
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Types ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Types.pm6
+    Stage start      :   0.000
+    Stage parse      :   8.333
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.260
+    Stage mast       :   1.268
+    Stage mbc        :   0.022
+Stage parse      :  11.039
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.010
+Stage mast       :   0.023
+Stage mbc        :   0.012
+Stage moar       :   0.000
+ === GTK::Compat::X11_Types ===
+Stage start      :   0.000
+Stage parse      :   1.223
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::Utils ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Utils.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.541
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.047
+    Stage mast       :   0.141
+    Stage mbc        :   0.007
+Stage parse      :   3.423
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Roles::Protection ===
+Stage start      :   0.000
+Stage parse      :   1.022
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Types ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Types.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.342
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.090
+    Stage mbc        :   0.007
+Stage parse      :   3.204
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GDK::Raw::Main ===
+Stage start      :   0.000
+
+    precomp lib/GDK/Raw/Main.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.712
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.088
+    Stage mbc        :   0.006
+Stage parse      :   3.962
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Raw::ObjectManagerServer ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/ObjectManagerServer.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.903
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.041
+    Stage mast       :   0.078
+    Stage mbc        :   0.006
+Stage parse      :   3.156
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Raw::Types ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/Types.pm6
+    Stage start      :   0.000
+    Stage parse      :   6.013
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.107
+    Stage mast       :   0.454
+    Stage mbc        :   0.016
+Stage parse      :   7.743
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.002
+Stage mast       :   0.006
+Stage mbc        :   0.002
+Stage moar       :   0.000
+ === GIO::DBus::Raw::Utils ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/Utils.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.100
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.030
+    Stage mast       :   0.142
+    Stage mbc        :   0.007
+Stage parse      :   4.435
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Roles::Signals::AuthObserver ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Roles/Signals/AuthObserver.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.544
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.084
+    Stage mbc        :   0.005
+Stage parse      :   2.782
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Roles::Signals::Connection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Roles/Signals/Connection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.463
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.017
+    Stage mast       :   0.079
+    Stage mbc        :   0.005
+Stage parse      :   2.695
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Roles::Signals::InterfaceSkeleton ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Roles/Signals/InterfaceSkeleton.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.478
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.073
+    Stage mbc        :   0.005
+Stage parse      :   2.711
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Roles::Signals::Object ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Roles/Signals/Object.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.411
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.075
+    Stage mbc        :   0.005
+Stage parse      :   2.649
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Roles::Signals::ObjectManager ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Roles/Signals/ObjectManager.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.585
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.100
+    Stage mbc        :   0.006
+Stage parse      :   2.846
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Roles::Signals::ObjectManagerClient ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Roles/Signals/ObjectManagerClient.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.637
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.093
+    Stage mbc        :   0.006
+Stage parse      :   2.904
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Roles::Signals::ObjectSkeleton ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Roles/Signals/ObjectSkeleton.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.469
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.075
+    Stage mbc        :   0.005
+Stage parse      :   2.712
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Roles::Signals::Proxy ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Roles/Signals/Proxy.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.600
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.097
+    Stage mbc        :   0.006
+Stage parse      :   2.859
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Roles::Signals::Server ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Roles/Signals/Server.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.379
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.070
+    Stage mbc        :   0.007
+Stage parse      :   2.597
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Utils ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Utils.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.286
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.036
+    Stage mast       :   0.137
+    Stage mbc        :   0.009
+Stage parse      :   2.616
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Action ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Action.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.290
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.090
+    Stage mbc        :   0.007
+Stage parse      :   3.522
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::ActionGroup ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/ActionGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.591
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.121
+    Stage mbc        :   0.006
+Stage parse      :   3.856
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::AppInfo ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/AppInfo.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.182
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.049
+    Stage mast       :   0.208
+    Stage mbc        :   0.008
+Stage parse      :   6.589
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::AsyncInitable ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/AsyncInitable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.652
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.076
+    Stage mbc        :   0.007
+Stage parse      :   2.874
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::AsyncResult ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/AsyncResult.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.609
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.074
+    Stage mbc        :   0.005
+Stage parse      :   2.813
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::BufferedInputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/BufferedInputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.312
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.092
+    Stage mbc        :   0.006
+Stage parse      :   3.584
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::BufferedOutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/BufferedOutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.878
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.013
+    Stage mast       :   0.081
+    Stage mbc        :   0.006
+Stage parse      :   3.087
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Cancellable ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Cancellable.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.586
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.096
+    Stage mbc        :   0.007
+Stage parse      :   3.827
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::CharsetConverter ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/CharsetConverter.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.615
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.013
+    Stage mast       :   0.077
+    Stage mbc        :   0.006
+Stage parse      :   2.836
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::ContentType ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/ContentType.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.556
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.094
+    Stage mbc        :   0.007
+Stage parse      :   3.819
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Credentials ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Credentials.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.181
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.085
+    Stage mbc        :   0.006
+Stage parse      :   3.412
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::DataInputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/DataInputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.150
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.149
+    Stage mbc        :   0.006
+Stage parse      :   4.466
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::DatagramBased ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/DatagramBased.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.736
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.079
+    Stage mbc        :   0.006
+Stage parse      :   2.971
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::EmblemedIcon ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/EmblemedIcon.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.680
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.013
+    Stage mast       :   0.079
+    Stage mbc        :   0.006
+Stage parse      :   2.897
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::FileEnumerator ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/FileEnumerator.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.403
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.039
+    Stage mast       :   0.109
+    Stage mbc        :   0.006
+Stage parse      :   3.675
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::FileIOStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/FileIOStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.596
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.055
+    Stage mast       :   0.069
+    Stage mbc        :   0.005
+Stage parse      :   2.828
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::FilenameCompleter ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/FilenameCompleter.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.583
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.080
+    Stage mbc        :   0.005
+Stage parse      :   2.805
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::FilterInputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/FilterInputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.504
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.014
+    Stage mast       :   0.067
+    Stage mbc        :   0.005
+Stage parse      :   2.711
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::FilterOutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/FilterOutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.481
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.014
+    Stage mast       :   0.071
+    Stage mbc        :   0.005
+Stage parse      :   2.687
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Icon ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Icon.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.907
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.080
+    Stage mbc        :   0.005
+Stage parse      :   3.118
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::InetAddress ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/InetAddress.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.129
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.028
+    Stage mast       :   0.115
+    Stage mbc        :   0.028
+Stage parse      :   4.410
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::InetAddressMask ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/InetAddressMask.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.019
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.083
+    Stage mbc        :   0.007
+Stage parse      :   3.253
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::InetSocketAddress ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/InetSocketAddress.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.924
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.085
+    Stage mbc        :   0.005
+Stage parse      :   3.168
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::InputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/InputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.075
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.037
+    Stage mast       :   0.138
+    Stage mbc        :   0.006
+Stage parse      :   4.378
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::ListModel ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/ListModel.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.704
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.078
+    Stage mbc        :   0.005
+Stage parse      :   2.929
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::ListStore ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/ListStore.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.920
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.030
+    Stage mast       :   0.082
+    Stage mbc        :   0.007
+Stage parse      :   3.154
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::MemoryInputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/MemoryInputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.705
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.077
+    Stage mbc        :   0.007
+Stage parse      :   2.922
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::MemoryOutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/MemoryOutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.880
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.079
+    Stage mbc        :   0.005
+Stage parse      :   3.103
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::MountOperation ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/MountOperation.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.139
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.119
+    Stage mbc        :   0.006
+Stage parse      :   4.442
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::NetworkAddress ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/NetworkAddress.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.888
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.082
+    Stage mbc        :   0.005
+Stage parse      :   3.118
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::NetworkMonitor ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/NetworkMonitor.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.967
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.087
+    Stage mbc        :   0.007
+Stage parse      :   3.194
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::NetworkService ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/NetworkService.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.769
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.081
+    Stage mbc        :   0.005
+Stage parse      :   2.969
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Notification ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Notification.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.086
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.087
+    Stage mbc        :   0.005
+Stage parse      :   3.328
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::OutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/OutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.087
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.055
+    Stage mast       :   0.167
+    Stage mbc        :   0.007
+Stage parse      :   5.445
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Permission ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Permission.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.226
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.087
+    Stage mbc        :   0.007
+Stage parse      :   3.468
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::PollableInputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/PollableInputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.594
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.076
+    Stage mbc        :   0.005
+Stage parse      :   2.805
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::PollableOutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/PollableOutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.803
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.041
+    Stage mast       :   0.073
+    Stage mbc        :   0.005
+Stage parse      :   3.035
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Proxy ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Proxy.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.758
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.083
+    Stage mbc        :   0.006
+Stage parse      :   2.983
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::ProxyAddress ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/ProxyAddress.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.986
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.044
+    Stage mast       :   0.079
+    Stage mbc        :   0.005
+Stage parse      :   3.231
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::ProxyResolver ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/ProxyResolver.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.717
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.047
+    Stage mast       :   0.075
+    Stage mbc        :   0.005
+Stage parse      :   2.978
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Resolver ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Resolver.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.210
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.039
+    Stage mast       :   0.142
+    Stage mbc        :   0.007
+Stage parse      :   4.518
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Seekable ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Seekable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.684
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.074
+    Stage mbc        :   0.005
+Stage parse      :   2.899
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::SettingsBackend ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/SettingsBackend.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.318
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.099
+    Stage mbc        :   0.006
+Stage parse      :   3.597
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::SettingsSchema ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/SettingsSchema.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.590
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.034
+    Stage mast       :   0.138
+    Stage mbc        :   0.007
+Stage parse      :   4.896
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::SimpleAction ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/SimpleAction.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.690
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.014
+    Stage mast       :   0.075
+    Stage mbc        :   0.007
+Stage parse      :   2.932
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::SimpleProxyResolver ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/SimpleProxyResolver.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.737
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.013
+    Stage mast       :   0.078
+    Stage mbc        :   0.007
+Stage parse      :   2.943
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Socket ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Socket.pm6
+    Stage start      :   0.000
+    Stage parse      :   6.549
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.099
+    Stage mast       :   0.267
+    Stage mbc        :   0.009
+Stage parse      :   8.056
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::SocketAddress ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/SocketAddress.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.600
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.081
+    Stage mbc        :   0.005
+Stage parse      :   2.810
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::SocketConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/SocketConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.251
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.095
+    Stage mbc        :   0.007
+Stage parse      :   3.504
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::SocketControlMessage ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/SocketControlMessage.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.806
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.013
+    Stage mast       :   0.085
+    Stage mbc        :   0.007
+Stage parse      :   3.035
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.002
+Stage mast       :   0.007
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::SocketListener ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/SocketListener.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.570
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.114
+    Stage mbc        :   0.006
+Stage parse      :   3.843
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::SocketService ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/SocketService.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.584
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.011
+    Stage mast       :   0.073
+    Stage mbc        :   0.006
+Stage parse      :   2.790
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::SrvTarget ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/SrvTarget.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.979
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.082
+    Stage mbc        :   0.007
+Stage parse      :   3.214
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Stream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Stream.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.327
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.097
+    Stage mbc        :   0.006
+Stage parse      :   3.579
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Subs ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Subs.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.319
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.012
+    Stage mast       :   0.055
+    Stage mbc        :   0.005
+Stage parse      :   2.519
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Task ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Task.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.375
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.043
+    Stage mast       :   0.171
+    Stage mbc        :   0.007
+Stage parse      :   5.722
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::ThemedIcon ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/ThemedIcon.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.763
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.013
+    Stage mast       :   0.085
+    Stage mbc        :   0.006
+Stage parse      :   2.990
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::TlsBackend ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/TlsBackend.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.260
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.042
+    Stage mast       :   0.083
+    Stage mbc        :   0.006
+Stage parse      :   3.496
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::UnixConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/UnixConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.035
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.088
+    Stage mbc        :   0.006
+Stage parse      :   3.281
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::UnixCredentialsMessage ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/UnixCredentialsMessage.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.582
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.012
+    Stage mast       :   0.071
+    Stage mbc        :   0.006
+Stage parse      :   2.788
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::UnixFDList ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/UnixFDList.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.034
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.081
+    Stage mbc        :   0.005
+Stage parse      :   3.286
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::UnixFDMessage ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/UnixFDMessage.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.720
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.013
+    Stage mast       :   0.081
+    Stage mbc        :   0.007
+Stage parse      :   2.943
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::UnixInputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/UnixInputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.598
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.075
+    Stage mbc        :   0.005
+Stage parse      :   2.811
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::UnixMount ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/UnixMount.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.132
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.043
+    Stage mast       :   0.178
+    Stage mbc        :   0.007
+Stage parse      :   6.488
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::UnixOutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/UnixOutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.611
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.079
+    Stage mbc        :   0.005
+Stage parse      :   2.822
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::UnixSocketAddress ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/UnixSocketAddress.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.892
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.014
+    Stage mast       :   0.082
+    Stage mbc        :   0.007
+Stage parse      :   3.108
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::VFS ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/VFS.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.283
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.087
+    Stage mbc        :   0.006
+Stage parse      :   3.517
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::VolumeMonitor ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/VolumeMonitor.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.995
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.086
+    Stage mbc        :   0.006
+Stage parse      :   3.213
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::ActionGroup ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/ActionGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.487
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.034
+    Stage mast       :   0.112
+    Stage mbc        :   0.007
+Stage parse      :   2.775
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::ActionMap ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/ActionMap.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.824
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.094
+    Stage mbc        :   0.006
+Stage parse      :   3.733
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GIO::Roles::AsyncResult ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/AsyncResult.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.282
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.081
+    Stage mbc        :   0.007
+Stage parse      :   2.522
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Converter ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Converter.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.542
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.081
+    Stage mbc        :   0.005
+Stage parse      :   2.761
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::FileDescriptorBased ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/FileDescriptorBased.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.391
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.063
+    Stage mbc        :   0.005
+Stage parse      :   2.596
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Initable ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Initable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.537
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.071
+    Stage mbc        :   0.005
+Stage parse      :   2.743
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::NetworkMonitor ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/NetworkMonitor.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.445
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.088
+    Stage mbc        :   0.005
+Stage parse      :   2.690
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::PollableInputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/PollableInputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.242
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.017
+    Stage mast       :   0.071
+    Stage mbc        :   0.006
+Stage parse      :   2.456
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::ProxyResolver ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/ProxyResolver.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.287
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.078
+    Stage mbc        :   0.007
+Stage parse      :   2.538
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::RemoteActionGroup ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/RemoteActionGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.570
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.078
+    Stage mbc        :   0.005
+Stage parse      :   2.823
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Seekable ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Seekable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.397
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.075
+    Stage mbc        :   0.007
+Stage parse      :   2.648
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Signals::ListModel ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Signals/ListModel.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.421
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.069
+    Stage mbc        :   0.006
+Stage parse      :   2.632
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Signals::MountOperation ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Signals/MountOperation.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.077
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.036
+    Stage mast       :   0.160
+    Stage mbc        :   0.005
+Stage parse      :   3.385
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Signals::Proxy ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Signals/Proxy.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.623
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.094
+    Stage mbc        :   0.006
+Stage parse      :   2.891
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Signals::SocketService ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Signals/SocketService.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.401
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.070
+    Stage mbc        :   0.005
+Stage parse      :   2.611
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Signals::VolumeMonitor ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Signals/VolumeMonitor.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.831
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.028
+    Stage mast       :   0.122
+    Stage mbc        :   0.006
+Stage parse      :   3.109
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::SettingsSchema ===
+Stage start      :   0.000
+
+    precomp lib/GIO/SettingsSchema.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.768
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.038
+    Stage mast       :   0.127
+    Stage mbc        :   0.007
+Stage parse      :   3.077
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::Arrays ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/Arrays.pm6
+    Stage start      :   0.000
+    Stage parse      :   6.205
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.067
+    Stage mast       :   0.236
+    Stage mbc        :   0.009
+Stage parse      :   7.645
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::AsyncQueue ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/AsyncQueue.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.485
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.132
+    Stage mbc        :   0.007
+Stage parse      :   4.784
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::Base64 ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/Base64.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.713
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.037
+    Stage mast       :   0.077
+    Stage mbc        :   0.005
+Stage parse      :   2.957
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::Bytes ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/Bytes.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.521
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.098
+    Stage mbc        :   0.006
+Stage parse      :   3.768
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::Checksum ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/Checksum.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.229
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.089
+    Stage mbc        :   0.006
+Stage parse      :   3.479
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::Error ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/Error.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.799
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.073
+    Stage mbc        :   0.005
+Stage parse      :   3.020
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::HMAC ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/HMAC.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.140
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.085
+    Stage mbc        :   0.007
+Stage parse      :   3.360
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::Module ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/Module.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.880
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.077
+    Stage mbc        :   0.007
+Stage parse      :   3.099
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::Quark ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/Quark.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.678
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.013
+    Stage mast       :   0.078
+    Stage mbc        :   0.007
+Stage parse      :   2.906
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::Quarks ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/Quarks.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.274
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.011
+    Stage mast       :   0.063
+    Stage mbc        :   0.005
+Stage parse      :   2.465
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::Rand ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/Rand.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.670
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.099
+    Stage mbc        :   0.008
+Stage parse      :   3.919
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::Scanner ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/Scanner.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.011
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.120
+    Stage mbc        :   0.007
+Stage parse      :   4.300
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::String ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/String.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.940
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.150
+    Stage mbc        :   0.043
+Stage parse      :   5.300
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::Tree ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/Tree.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.762
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.152
+    Stage mbc        :   0.007
+Stage parse      :   5.097
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Raw::Unicode ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Raw/Unicode.pm6
+    Stage start      :   0.000
+    Stage parse      :   7.439
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.068
+    Stage mast       :   0.277
+    Stage mbc        :   0.009
+Stage parse      :   8.922
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Scanner ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Scanner.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.211
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.139
+    Stage mbc        :   0.009
+Stage parse      :   2.520
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::String ===
+Stage start      :   0.000
+
+    precomp lib/GLib/String.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.317
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.046
+    Stage mast       :   0.130
+    Stage mbc        :   0.009
+Stage parse      :   2.637
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.006
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Tree ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Tree.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.265
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.123
+    Stage mbc        :   0.008
+Stage parse      :   2.569
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::URI ===
+Stage start      :   0.000
+
+    precomp lib/GLib/URI.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.562
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.078
+    Stage mbc        :   0.008
+Stage parse      :   2.789
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Unicode ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Unicode.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.934
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.272
+    Stage mast       :   0.333
+    Stage mbc        :   0.012
+Stage parse      :   3.714
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Builder::Actionable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder/Actionable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.045
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.004
+    Stage mast       :   0.027
+    Stage mbc        :   0.001
+Stage parse      :   2.144
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::FileTypes ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/FileTypes.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.903
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.216
+    Stage mbc        :   0.007
+Stage parse      :   4.276
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.002
+Stage mast       :   0.006
+Stage mbc        :   0.002
+Stage moar       :   0.000
+ === GTK::Compat::Pixbuf::Raw::Animation ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Pixbuf/Raw/Animation.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.967
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.133
+    Stage mbc        :   0.006
+Stage parse      :   4.261
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::RGBA ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/RGBA.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.987
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.036
+    Stage mast       :   0.098
+    Stage mbc        :   0.006
+Stage parse      :   3.878
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Compat::Raw::AppLaunchContext ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/AppLaunchContext.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.682
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.080
+    Stage mbc        :   0.005
+Stage parse      :   2.896
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Array ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Array.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.931
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.057
+    Stage mast       :   0.207
+    Stage mbc        :   0.008
+Stage parse      :   7.344
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Binding ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Binding.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.152
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.095
+    Stage mbc        :   0.007
+Stage parse      :   3.406
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::BookmarkFile ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/BookmarkFile.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.030
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.057
+    Stage mast       :   0.222
+    Stage mbc        :   0.008
+Stage parse      :   6.465
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Cursor ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Cursor.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.446
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.093
+    Stage mbc        :   0.008
+Stage parse      :   4.302
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Compat::Raw::DateTime ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/DateTime.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.662
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.053
+    Stage mast       :   0.217
+    Stage mbc        :   0.008
+Stage parse      :   7.081
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Device ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Device.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.466
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.047
+    Stage mast       :   0.183
+    Stage mbc        :   0.008
+Stage parse      :   5.860
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Display ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Display.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.690
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.053
+    Stage mast       :   0.205
+    Stage mbc        :   0.008
+Stage parse      :   7.663
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::DisplayManager ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/DisplayManager.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.708
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.014
+    Stage mast       :   0.080
+    Stage mbc        :   0.007
+Stage parse      :   2.944
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::DragContext ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/DragContext.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.586
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.041
+    Stage mast       :   0.150
+    Stage mbc        :   0.007
+Stage parse      :   4.917
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::FrameTimings ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/FrameTimings.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.102
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.087
+    Stage mbc        :   0.005
+Stage parse      :   3.345
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::GFile ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/GFile.pm6
+    Stage start      :   0.000
+    Stage parse      :  13.214
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.168
+    Stage mast       :   0.532
+    Stage mbc        :   0.015
+Stage parse      :  15.094
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.002
+Stage mast       :   0.006
+Stage mbc        :   0.002
+Stage moar       :   0.000
+ === GTK::Compat::Raw::GList ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/GList.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.133
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.041
+    Stage mast       :   0.161
+    Stage mbc        :   0.016
+Stage parse      :   6.071
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Compat::Raw::GSList ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/GSList.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.893
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.038
+    Stage mast       :   0.151
+    Stage mbc        :   0.007
+Stage parse      :   5.768
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Compat::Raw::HashTable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/HashTable.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.295
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.051
+    Stage mast       :   0.196
+    Stage mbc        :   0.008
+Stage parse      :   6.681
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::IOChannel ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/IOChannel.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.015
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.050
+    Stage mast       :   0.197
+    Stage mbc        :   0.008
+Stage parse      :   6.404
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::IsType ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/IsType.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.134
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.010
+    Stage mast       :   0.091
+    Stage mbc        :   0.009
+Stage parse      :   2.939
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Compat::Raw::KeyFile ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/KeyFile.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.347
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.069
+    Stage mast       :   0.265
+    Stage mbc        :   0.008
+Stage parse      :   6.827
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Keymap ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Keymap.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.517
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.164
+    Stage mbc        :   0.006
+Stage parse      :   4.833
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Log ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Log.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.187
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.044
+    Stage mast       :   0.130
+    Stage mbc        :   0.006
+Stage parse      :   4.487
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Main ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Main.pm6
+    Stage start      :   0.000
+    Stage parse      :   9.127
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.077
+    Stage mast       :   0.338
+    Stage mbc        :   0.010
+Stage parse      :  10.704
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.002
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Menu ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Menu.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.023
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.043
+    Stage mast       :   0.175
+    Stage mbc        :   0.007
+Stage parse      :   5.394
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::MenuModel ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/MenuModel.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.778
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.108
+    Stage mbc        :   0.006
+Stage parse      :   4.051
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Notification ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Notification.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.143
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.081
+    Stage mbc        :   0.007
+Stage parse      :   3.386
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Pixbuf ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Pixbuf.pm6
+    Stage start      :   0.000
+    Stage parse      :   6.327
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.100
+    Stage mast       :   0.229
+    Stage mbc        :   0.009
+Stage parse      :   8.425
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Pixbuf::Transforms ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Pixbuf/Transforms.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.901
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.102
+    Stage mbc        :   0.005
+Stage parse      :   3.737
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Rectangle ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Rectangle.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.504
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.073
+    Stage mbc        :   0.005
+Stage parse      :   2.709
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Screen ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Screen.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.149
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.038
+    Stage mast       :   0.164
+    Stage mbc        :   0.007
+Stage parse      :   6.061
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Seat ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Seat.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.955
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.079
+    Stage mbc        :   0.005
+Stage parse      :   3.175
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Selection ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Selection.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.009
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.089
+    Stage mbc        :   0.007
+Stage parse      :   3.250
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Signal ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Signal.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.318
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.053
+    Stage mast       :   0.188
+    Stage mbc        :   0.008
+Stage parse      :   5.690
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Slice ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Slice.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.095
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.080
+    Stage mbc        :   0.005
+Stage parse      :   3.321
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Thread ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Thread.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.739
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.041
+    Stage mast       :   0.159
+    Stage mbc        :   0.008
+Stage parse      :   6.099
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::ThreadPool ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/ThreadPool.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.567
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.096
+    Stage mbc        :   0.006
+Stage parse      :   3.816
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::TimeZone ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/TimeZone.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.313
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.087
+    Stage mbc        :   0.006
+Stage parse      :   3.537
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Timer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Timer.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.196
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.084
+    Stage mbc        :   0.007
+Stage parse      :   3.427
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Value ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Value.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.856
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.056
+    Stage mast       :   0.206
+    Stage mbc        :   0.009
+Stage parse      :   7.815
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Variant ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Variant.pm6
+    Stage start      :   0.000
+    Stage parse      :  10.241
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.104
+    Stage mast       :   0.339
+    Stage mbc        :   0.011
+Stage parse      :  11.826
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.002
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::VariantType ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/VariantType.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.962
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.036
+    Stage mast       :   0.144
+    Stage mbc        :   0.007
+Stage parse      :   5.288
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Visual ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Visual.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.048
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.140
+    Stage mbc        :   0.005
+Stage parse      :   4.343
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Window ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Window.pm6
+    Stage start      :   0.000
+    Stage parse      :  16.913
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.167
+    Stage mast       :   0.525
+    Stage mbc        :   0.016
+Stage parse      :  19.440
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.003
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::X11_Display ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/X11_Display.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.605
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.100
+    Stage mbc        :   0.006
+Stage parse      :   4.424
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Compat::Raw::X11_Screen ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/X11_Screen.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.053
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.083
+    Stage mbc        :   0.006
+Stage parse      :   3.845
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Compat::Raw::X11_Window ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/X11_Window.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.347
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.092
+    Stage mbc        :   0.008
+Stage parse      :   4.208
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Compat::Rectangle ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Rectangle.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.241
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.075
+    Stage mbc        :   0.007
+Stage parse      :   2.475
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Roles::ListData ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Roles/ListData.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.333
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.052
+    Stage mast       :   0.085
+    Stage mbc        :   0.007
+Stage parse      :   3.152
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Compat::Roles::Signals::Window ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Roles/Signals/Window.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.994
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.151
+    Stage mbc        :   0.006
+Stage parse      :   3.895
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Compat::Roles::TypedBuffer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Roles/TypedBuffer.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.367
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.077
+    Stage mbc        :   0.006
+Stage parse      :   2.619
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Selection ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Selection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.208
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.108
+    Stage mbc        :   0.007
+Stage parse      :   2.529
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Signal ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Signal.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.508
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.064
+    Stage mast       :   0.170
+    Stage mbc        :   0.008
+Stage parse      :   2.874
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Slice ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Slice.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.177
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.077
+    Stage mbc        :   0.007
+Stage parse      :   2.402
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.007
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::ThreadPool ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/ThreadPool.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.349
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.121
+    Stage mbc        :   0.008
+Stage parse      :   2.650
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::TimeZone ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/TimeZone.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.172
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.103
+    Stage mbc        :   0.007
+Stage parse      :   2.448
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Timer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Timer.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.400
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.077
+    Stage mbc        :   0.007
+Stage parse      :   2.635
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Variant ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Variant.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.491
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.079
+    Stage mast       :   0.203
+    Stage mbc        :   0.012
+Stage parse      :   3.929
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::VariantIter ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/VariantIter.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.265
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.084
+    Stage mbc        :   0.009
+Stage parse      :   2.512
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::VariantType ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/VariantType.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.250
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.156
+    Stage mbc        :   0.008
+Stage parse      :   2.608
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.004
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Visual ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Visual.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.333
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.090
+    Stage mbc        :   0.007
+Stage parse      :   2.578
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Types ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Types.pm6
+    Stage start      :   0.000
+    Stage parse      :   8.287
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.112
+    Stage mast       :   0.968
+    Stage mbc        :   0.019
+Stage parse      :  11.252
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.004
+Stage mast       :   0.009
+Stage mbc        :   0.004
+Stage moar       :   0.000
+ === GTK::Raw::Viewport ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Viewport.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.588
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.093
+    Stage mbc        :   0.008
+Stage parse      :   3.880
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::VolumeButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/VolumeButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.416
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.075
+    Stage mbc        :   0.007
+Stage parse      :   2.669
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Widget ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Widget.pm6
+    Stage start      :   0.000
+    Stage parse      :  31.672
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.254
+    Stage mast       :   0.653
+    Stage mbc        :   0.022
+Stage parse      :  34.436
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::WidgetPath ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/WidgetPath.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.900
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.053
+    Stage mast       :   0.182
+    Stage mbc        :   0.011
+Stage parse      :   7.868
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::Window ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Window.pm6
+    Stage start      :   0.000
+    Stage parse      :  16.299
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.118
+    Stage mast       :   0.411
+    Stage mbc        :   0.016
+Stage parse      :  18.598
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.007
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::WindowGroup ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/WindowGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.021
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.095
+    Stage mbc        :   0.008
+Stage parse      :   3.277
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::EntryBuffer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/EntryBuffer.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.530
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.089
+    Stage mbc        :   0.008
+Stage parse      :   2.808
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::StyleProvider ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/StyleProvider.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.688
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.055
+    Stage mast       :   0.077
+    Stage mbc        :   0.009
+Stage parse      :   2.986
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GDK::Main ===
+Stage start      :   0.000
+
+    precomp lib/GDK/Main.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.161
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.095
+    Stage mbc        :   0.007
+Stage parse      :   2.409
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GDK::Raw::Threads ===
+Stage start      :   0.000
+
+    precomp lib/GDK/Raw/Threads.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.931
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.090
+    Stage mbc        :   0.009
+Stage parse      :   3.207
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GDK::Threads ===
+Stage start      :   0.000
+
+    precomp lib/GDK/Threads.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.221
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.107
+    Stage mbc        :   0.007
+Stage parse      :   2.529
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::ContentType ===
+Stage start      :   0.000
+
+    precomp lib/GIO/ContentType.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.308
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.115
+    Stage mbc        :   0.006
+Stage parse      :   2.590
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Raw::Address ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/Address.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.932
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.039
+    Stage mast       :   0.082
+    Stage mbc        :   0.006
+Stage parse      :   3.185
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Raw::Connection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/Connection.pm6
+    Stage start      :   0.000
+    Stage parse      :   6.264
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.087
+    Stage mast       :   0.236
+    Stage mbc        :   0.009
+Stage parse      :   7.744
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Raw::Error ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/Error.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.205
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.097
+    Stage mbc        :   0.006
+Stage parse      :   3.478
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Raw::Interface ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/Interface.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.765
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.076
+    Stage mbc        :   0.006
+Stage parse      :   2.995
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Raw::InterfaceSkeleton ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/InterfaceSkeleton.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.596
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.112
+    Stage mbc        :   0.007
+Stage parse      :   3.889
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Raw::Message ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/Message.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.986
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.058
+    Stage mast       :   0.216
+    Stage mbc        :   0.009
+Stage parse      :   7.426
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Raw::MethodInvocation ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/MethodInvocation.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.120
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.124
+    Stage mbc        :   0.008
+Stage parse      :   4.442
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Raw::ObjectManager ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/ObjectManager.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.652
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.084
+    Stage mbc        :   0.006
+Stage parse      :   2.895
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Raw::ObjectManagerClient ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/ObjectManagerClient.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.280
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.112
+    Stage mbc        :   0.006
+Stage parse      :   3.568
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Raw::ObjectSkeleton ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/ObjectSkeleton.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.852
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.076
+    Stage mbc        :   0.006
+Stage parse      :   3.107
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Raw::Proxy ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/Proxy.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.844
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.046
+    Stage mast       :   0.159
+    Stage mbc        :   0.008
+Stage parse      :   5.245
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Raw::Server ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Raw/Server.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.075
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.046
+    Stage mast       :   0.084
+    Stage mbc        :   0.006
+Stage parse      :   3.373
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Roles::Interface ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Roles/Interface.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.308
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.030
+    Stage mast       :   0.077
+    Stage mbc        :   0.007
+Stage parse      :   2.564
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Roles::ObjectManager ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Roles/ObjectManager.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.444
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.104
+    Stage mbc        :   0.006
+Stage parse      :   2.740
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::LaunchContext ===
+Stage start      :   0.000
+
+    precomp lib/GIO/LaunchContext.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.302
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.099
+    Stage mbc        :   0.008
+Stage parse      :   2.582
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::DataOutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/DataOutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.415
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.034
+    Stage mast       :   0.109
+    Stage mbc        :   0.007
+Stage parse      :   3.695
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::DesktopAppInfo ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/DesktopAppInfo.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.987
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.037
+    Stage mast       :   0.159
+    Stage mbc        :   0.008
+Stage parse      :   5.338
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Drive ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Drive.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.852
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.038
+    Stage mast       :   0.148
+    Stage mbc        :   0.008
+Stage parse      :   5.192
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::DtlsClientConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/DtlsClientConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.843
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.081
+    Stage mbc        :   0.006
+Stage parse      :   3.076
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::DtlsConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/DtlsConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.576
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.177
+    Stage mbc        :   0.007
+Stage parse      :   4.960
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Emblem ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Emblem.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.648
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.072
+    Stage mbc        :   0.006
+Stage parse      :   2.862
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::FileAttributeInfoList ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/FileAttributeInfoList.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.843
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.082
+    Stage mbc        :   0.006
+Stage parse      :   3.077
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::FileInfo ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/FileInfo.pm6
+    Stage start      :   0.000
+    Stage parse      :   8.376
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.078
+    Stage mast       :   0.315
+    Stage mbc        :   0.010
+Stage parse      :   9.931
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::FileMonitor ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/FileMonitor.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.753
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.095
+    Stage mbc        :   0.005
+Stage parse      :   2.986
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Mount ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Mount.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.639
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.145
+    Stage mbc        :   0.008
+Stage parse      :   4.966
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Quarks ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Quarks.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.168
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.004
+    Stage mast       :   0.047
+    Stage mbc        :   0.002
+Stage parse      :   2.346
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Resource ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Resource.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.928
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.123
+    Stage mbc        :   0.007
+Stage parse      :   4.240
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Settings ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Settings.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.637
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.063
+    Stage mast       :   0.226
+    Stage mbc        :   0.009
+Stage parse      :   7.080
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::SocketClient ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/SocketClient.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.539
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.049
+    Stage mast       :   0.169
+    Stage mbc        :   0.008
+Stage parse      :   5.889
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::TlsCertificate ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/TlsCertificate.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.026
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.084
+    Stage mbc        :   0.006
+Stage parse      :   3.283
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::TlsClientConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/TlsClientConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.230
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.090
+    Stage mbc        :   0.006
+Stage parse      :   3.494
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::TlsConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/TlsConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.172
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.132
+    Stage mbc        :   0.007
+Stage parse      :   4.487
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::TlsDatabase ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/TlsDatabase.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.685
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.131
+    Stage mbc        :   0.007
+Stage parse      :   3.975
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::TlsInteraction ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/TlsInteraction.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.231
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.107
+    Stage mbc        :   0.006
+Stage parse      :   3.502
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::TlsPassword ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/TlsPassword.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.315
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.093
+    Stage mbc        :   0.006
+Stage parse      :   3.545
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Raw::Volume ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Raw/Volume.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.074
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.140
+    Stage mbc        :   0.007
+Stage parse      :   4.383
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::AsyncInitable ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/AsyncInitable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.459
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.054
+    Stage mast       :   0.109
+    Stage mbc        :   0.063
+Stage parse      :   2.840
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Icon ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Icon.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.412
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.052
+    Stage mast       :   0.078
+    Stage mbc        :   0.006
+Stage parse      :   2.714
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Signals::DtlsConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Signals/DtlsConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.449
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.017
+    Stage mast       :   0.075
+    Stage mbc        :   0.005
+Stage parse      :   2.665
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Signals::FileMonitor ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Signals/FileMonitor.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.442
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.072
+    Stage mbc        :   0.005
+Stage parse      :   2.656
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Signals::TlsConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Signals/TlsConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.455
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.074
+    Stage mbc        :   0.006
+Stage parse      :   2.698
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::AsyncQueue ===
+Stage start      :   0.000
+
+    precomp lib/GLib/AsyncQueue.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.329
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.038
+    Stage mast       :   0.109
+    Stage mbc        :   0.008
+Stage parse      :   2.617
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Base64 ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Base64.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.232
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.038
+    Stage mast       :   0.110
+    Stage mbc        :   0.007
+Stage parse      :   2.505
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Bytes ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Bytes.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.183
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.034
+    Stage mast       :   0.102
+    Stage mbc        :   0.009
+Stage parse      :   2.454
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Checksum ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Checksum.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.343
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.120
+    Stage mbc        :   0.008
+Stage parse      :   2.623
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Error ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Error.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.389
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.085
+    Stage mbc        :   0.006
+Stage parse      :   2.646
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::HMAC ===
+Stage start      :   0.000
+
+    precomp lib/GLib/HMAC.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.223
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.141
+    Stage mbc        :   0.007
+Stage parse      :   2.540
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Module ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Module.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.143
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.132
+    Stage mbc        :   0.008
+Stage parse      :   2.412
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Quark ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Quark.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.130
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.084
+    Stage mbc        :   0.008
+Stage parse      :   2.362
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::Rand ===
+Stage start      :   0.000
+
+    precomp lib/GLib/Rand.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.252
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.038
+    Stage mast       :   0.120
+    Stage mbc        :   0.008
+Stage parse      :   2.554
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Array ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Array.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.359
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.114
+    Stage mbc        :   0.008
+Stage parse      :   2.651
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::BookmarkFile ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/BookmarkFile.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.421
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.068
+    Stage mast       :   0.168
+    Stage mbc        :   0.010
+Stage parse      :   2.792
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::DateTime ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/DateTime.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.235
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.074
+    Stage mast       :   0.192
+    Stage mbc        :   0.009
+Stage parse      :   3.644
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::FrameTimings ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/FrameTimings.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.152
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.088
+    Stage mbc        :   0.007
+Stage parse      :   2.405
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::GList ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/GList.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.417
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.045
+    Stage mast       :   0.129
+    Stage mbc        :   0.008
+Stage parse      :   3.400
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.001
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Compat::GSList ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/GSList.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.397
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.043
+    Stage mast       :   0.131
+    Stage mbc        :   0.007
+Stage parse      :   2.728
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::IOChannel ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/IOChannel.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.338
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.052
+    Stage mast       :   0.167
+    Stage mbc        :   0.009
+Stage parse      :   2.713
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::KeyFile ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/KeyFile.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.397
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.072
+    Stage mast       :   0.178
+    Stage mbc        :   0.010
+Stage parse      :   2.787
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Keymap ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Keymap.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.365
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.039
+    Stage mast       :   0.148
+    Stage mbc        :   0.008
+Stage parse      :   2.724
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Log ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Log.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.391
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.038
+    Stage mast       :   0.138
+    Stage mbc        :   0.008
+Stage parse      :   2.708
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::MainContext ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/MainContext.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.394
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.039
+    Stage mast       :   0.117
+    Stage mbc        :   0.008
+Stage parse      :   2.713
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::MainLoop ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/MainLoop.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.393
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.078
+    Stage mbc        :   0.007
+Stage parse      :   2.646
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::MenuAttributeIter ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/MenuAttributeIter.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.137
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.014
+    Stage mast       :   0.104
+    Stage mbc        :   0.008
+Stage parse      :   2.384
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::MenuItem ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/MenuItem.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.337
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.043
+    Stage mast       :   0.095
+    Stage mbc        :   0.069
+Stage parse      :   2.717
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::MenuLinkIter ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/MenuLinkIter.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.125
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.086
+    Stage mbc        :   0.007
+Stage parse      :   2.352
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Mutex ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Mutex.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.131
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.069
+    Stage mbc        :   0.008
+Stage parse      :   2.374
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Pixbuf::Animation::Iter ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Pixbuf/Animation/Iter.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.165
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.067
+    Stage mbc        :   0.007
+Stage parse      :   2.390
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Pixbuf::Transforms ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Pixbuf/Transforms.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.444
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.154
+    Stage mbc        :   0.007
+Stage parse      :   3.436
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Compat::PtrArray ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/PtrArray.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.285
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.158
+    Stage mbc        :   0.009
+Stage parse      :   2.613
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Cairo ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Cairo.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.995
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.110
+    Stage mbc        :   0.010
+Stage parse      :   4.321
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Event ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Event.pm6
+    Stage start      :   0.000
+    Stage parse      :   6.524
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.053
+    Stage mast       :   0.198
+    Stage mbc        :   0.011
+Stage parse      :   7.953
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::FrameClock ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/FrameClock.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.397
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.110
+    Stage mbc        :   0.009
+Stage parse      :   3.707
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Source ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Source.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.318
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.125
+    Stage mbc        :   0.009
+Stage parse      :   2.661
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Timeout ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Timeout.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.233
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.107
+    Stage mbc        :   0.009
+Stage parse      :   2.552
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Dialog::Raw::About ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/Raw/About.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.362
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.045
+    Stage mast       :   0.173
+    Stage mbc        :   0.010
+Stage parse      :   6.754
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Dialog::Raw::AppChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/Raw/AppChooser.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.014
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.089
+    Stage mbc        :   0.009
+Stage parse      :   3.291
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Dialog::Raw::ColorChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/Raw/ColorChooser.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.414
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.076
+    Stage mbc        :   0.007
+Stage parse      :   2.650
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Dialog::Raw::FontChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/Raw/FontChooser.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.545
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.017
+    Stage mast       :   0.079
+    Stage mbc        :   0.008
+Stage parse      :   2.816
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Dialog::Raw::Message ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/Raw/Message.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.301
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.094
+    Stage mbc        :   0.009
+Stage parse      :   3.607
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Dialog::Raw::PageSetupUnix ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/Raw/PageSetupUnix.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.051
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.085
+    Stage mbc        :   0.009
+Stage parse      :   3.315
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Dialog::Raw::PrintUnix ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/Raw/PrintUnix.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.600
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.038
+    Stage mast       :   0.131
+    Stage mbc        :   0.010
+Stage parse      :   4.964
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::AccelGroup ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/AccelGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.327
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.044
+    Stage mast       :   0.161
+    Stage mbc        :   0.009
+Stage parse      :   5.698
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::AccelLabel ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/AccelLabel.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.286
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.107
+    Stage mbc        :   0.009
+Stage parse      :   3.565
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ActionBar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ActionBar.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.041
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.087
+    Stage mbc        :   0.009
+Stage parse      :   3.305
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Actionable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Actionable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.972
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.086
+    Stage mbc        :   0.008
+Stage parse      :   3.801
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::Adjustment ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Adjustment.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.637
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.145
+    Stage mbc        :   0.010
+Stage parse      :   5.581
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::AppButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/AppButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.555
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.028
+    Stage mast       :   0.099
+    Stage mbc        :   0.009
+Stage parse      :   3.858
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::AppChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/AppChooser.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.669
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.083
+    Stage mbc        :   0.009
+Stage parse      :   2.920
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Application ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Application.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.034
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.146
+    Stage mbc        :   0.010
+Stage parse      :   6.001
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::ApplicationWindow ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ApplicationWindow.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.026
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.041
+    Stage mast       :   0.084
+    Stage mbc        :   0.009
+Stage parse      :   3.785
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::AspectFrame ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/AspectFrame.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.539
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.079
+    Stage mbc        :   0.008
+Stage parse      :   2.801
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Assistant ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Assistant.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.838
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.053
+    Stage mast       :   0.172
+    Stage mbc        :   0.010
+Stage parse      :   6.223
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Bin ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Bin.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.620
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.063
+    Stage mbc        :   0.007
+Stage parse      :   3.458
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::Box ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Box.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.150
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.119
+    Stage mbc        :   0.009
+Stage parse      :   5.025
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::Buildable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Buildable.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.640
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.110
+    Stage mbc        :   0.008
+Stage parse      :   4.620
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::Builder ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Builder.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.567
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.044
+    Stage mast       :   0.164
+    Stage mbc        :   0.017
+Stage parse      :   5.943
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Button ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Button.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.583
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.042
+    Stage mast       :   0.143
+    Stage mbc        :   0.010
+Stage parse      :   6.551
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ButtonBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ButtonBox.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.267
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.101
+    Stage mbc        :   0.008
+Stage parse      :   3.552
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CSSProvider ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CSSProvider.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.459
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.090
+    Stage mbc        :   0.008
+Stage parse      :   3.739
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CSS_Section ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CSS_Section.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.495
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.096
+    Stage mbc        :   0.009
+Stage parse      :   3.783
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Calendar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Calendar.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.218
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.037
+    Stage mast       :   0.113
+    Stage mbc        :   0.030
+Stage parse      :   4.563
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellArea ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellArea.pm6
+    Stage start      :   0.000
+    Stage parse      :   6.470
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.074
+    Stage mast       :   0.249
+    Stage mbc        :   0.011
+Stage parse      :   7.986
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellAreaBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellAreaBox.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.006
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.082
+    Stage mbc        :   0.009
+Stage parse      :   3.275
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellAreaContext ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellAreaContext.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.727
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.101
+    Stage mbc        :   0.009
+Stage parse      :   4.012
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellEditable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellEditable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.673
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.079
+    Stage mbc        :   0.008
+Stage parse      :   2.946
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellLayout ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellLayout.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.562
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.030
+    Stage mast       :   0.103
+    Stage mbc        :   0.009
+Stage parse      :   3.848
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellRenderer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellRenderer.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.395
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.056
+    Stage mast       :   0.162
+    Stage mbc        :   0.010
+Stage parse      :   5.802
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellRendererAccel ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellRendererAccel.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.544
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.071
+    Stage mbc        :   0.009
+Stage parse      :   2.822
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellRendererCombo ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellRendererCombo.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.594
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.072
+    Stage mbc        :   0.007
+Stage parse      :   2.849
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellRendererPixbuf ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellRendererPixbuf.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.523
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.014
+    Stage mast       :   0.068
+    Stage mbc        :   0.007
+Stage parse      :   2.754
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellRendererProgress ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellRendererProgress.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.415
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.074
+    Stage mbc        :   0.007
+Stage parse      :   2.653
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellRendererSpin ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellRendererSpin.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.435
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.074
+    Stage mbc        :   0.007
+Stage parse      :   2.679
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellRendererSpinner ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellRendererSpinner.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.431
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.069
+    Stage mbc        :   0.007
+Stage parse      :   2.680
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellRendererText ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellRendererText.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.552
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.076
+    Stage mbc        :   0.008
+Stage parse      :   2.818
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellRendererToggle ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellRendererToggle.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.329
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.092
+    Stage mbc        :   0.009
+Stage parse      :   3.616
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CellView ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CellView.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.512
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.118
+    Stage mbc        :   0.009
+Stage parse      :   4.845
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CheckButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CheckButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.701
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.071
+    Stage mbc        :   0.008
+Stage parse      :   2.973
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::CheckMenuItem ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/CheckMenuItem.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.573
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.057
+    Stage mast       :   0.090
+    Stage mbc        :   0.008
+Stage parse      :   3.881
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Clipboard ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Clipboard.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.300
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.179
+    Stage mbc        :   0.010
+Stage parse      :   6.686
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ColorButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ColorButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.013
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.101
+    Stage mbc        :   0.009
+Stage parse      :   4.310
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ColorChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ColorChooser.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.176
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.041
+    Stage mast       :   0.088
+    Stage mbc        :   0.009
+Stage parse      :   3.479
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ComboBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ComboBox.pm6
+    Stage start      :   0.000
+    Stage parse      :   6.548
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.052
+    Stage mast       :   0.183
+    Stage mbc        :   0.011
+Stage parse      :   7.952
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ComboBoxText ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ComboBoxText.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.679
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.028
+    Stage mast       :   0.100
+    Stage mbc        :   0.009
+Stage parse      :   3.981
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Container ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Container.pm6
+    Stage start      :   0.000
+    Stage parse      :   6.236
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.054
+    Stage mast       :   0.195
+    Stage mbc        :   0.011
+Stage parse      :   8.287
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::Dialog ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Dialog.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.213
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.039
+    Stage mast       :   0.117
+    Stage mbc        :   0.009
+Stage parse      :   4.531
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::DnD ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/DnD.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.426
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.036
+    Stage mast       :   0.135
+    Stage mbc        :   0.010
+Stage parse      :   5.323
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::DragDest ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/DragDest.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.668
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.101
+    Stage mast       :   0.094
+    Stage mbc        :   0.009
+Stage parse      :   4.606
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::DragSource ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/DragSource.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.708
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.097
+    Stage mbc        :   0.009
+Stage parse      :   4.577
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::Editable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Editable.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.960
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.103
+    Stage mbc        :   0.009
+Stage parse      :   4.270
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Entry ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Entry.pm6
+    Stage start      :   0.000
+    Stage parse      :  11.071
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.080
+    Stage mast       :   0.321
+    Stage mbc        :   0.014
+Stage parse      :  12.666
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::EntryBuffer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/EntryBuffer.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.787
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.030
+    Stage mast       :   0.103
+    Stage mbc        :   0.009
+Stage parse      :   4.088
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::EntryCompletion ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/EntryCompletion.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.708
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.161
+    Stage mbc        :   0.010
+Stage parse      :   6.093
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::EventBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/EventBox.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.004
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.085
+    Stage mbc        :   0.009
+Stage parse      :   3.265
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Expander ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Expander.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.643
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.160
+    Stage mbc        :   0.009
+Stage parse      :   4.994
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::FileChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/FileChooser.pm6
+    Stage start      :   0.000
+    Stage parse      :   9.053
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.075
+    Stage mast       :   0.268
+    Stage mbc        :   0.013
+Stage parse      :  10.608
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::FileChooserButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/FileChooserButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.401
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.092
+    Stage mbc        :   0.009
+Stage parse      :   3.688
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::FileFilter ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/FileFilter.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.722
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.098
+    Stage mbc        :   0.009
+Stage parse      :   4.013
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Fixed ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Fixed.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.670
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.082
+    Stage mbc        :   0.008
+Stage parse      :   2.926
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::FlowBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/FlowBox.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.937
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.044
+    Stage mast       :   0.183
+    Stage mbc        :   0.010
+Stage parse      :   7.900
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::FontButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/FontButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.107
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.030
+    Stage mast       :   0.116
+    Stage mbc        :   0.010
+Stage parse      :   4.441
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::FontChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/FontChooser.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.173
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.119
+    Stage mbc        :   0.010
+Stage parse      :   4.503
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Frame ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Frame.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.575
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.095
+    Stage mbc        :   0.008
+Stage parse      :   3.846
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Grid ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Grid.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.916
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.038
+    Stage mast       :   0.147
+    Stage mbc        :   0.009
+Stage parse      :   5.279
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::HeaderBar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/HeaderBar.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.330
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.030
+    Stage mast       :   0.102
+    Stage mbc        :   0.009
+Stage parse      :   4.617
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::IconTheme ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/IconTheme.pm6
+    Stage start      :   0.000
+    Stage parse      :   7.514
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.072
+    Stage mast       :   0.377
+    Stage mbc        :   0.011
+Stage parse      :   9.137
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::IconView ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/IconView.pm6
+    Stage start      :   0.000
+    Stage parse      :   9.287
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.074
+    Stage mast       :   0.302
+    Stage mbc        :   0.013
+Stage parse      :  10.856
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Image ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Image.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.142
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.053
+    Stage mast       :   0.167
+    Stage mbc        :   0.010
+Stage parse      :   7.092
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::InfoBar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/InfoBar.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.120
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.028
+    Stage mast       :   0.108
+    Stage mbc        :   0.010
+Stage parse      :   4.424
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Label ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Label.pm6
+    Stage start      :   0.000
+    Stage parse      :   7.972
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.067
+    Stage mast       :   0.212
+    Stage mbc        :   0.013
+Stage parse      :  10.084
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Layout ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Layout.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.635
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.028
+    Stage mast       :   0.104
+    Stage mbc        :   0.009
+Stage parse      :   3.925
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::LevelBar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/LevelBar.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.187
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.042
+    Stage mast       :   0.108
+    Stage mbc        :   0.009
+Stage parse      :   4.508
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::LinkButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/LinkButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.029
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.095
+    Stage mbc        :   0.009
+Stage parse      :   3.309
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ListBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ListBox.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.938
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.049
+    Stage mast       :   0.184
+    Stage mbc        :   0.010
+Stage parse      :   7.366
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ListStore ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ListStore.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.493
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.144
+    Stage mbc        :   0.009
+Stage parse      :   4.845
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::LockButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/LockButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.673
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.074
+    Stage mbc        :   0.008
+Stage parse      :   2.926
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Main ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Main.pm6
+    Stage start      :   0.000
+    Stage parse      :   6.169
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.044
+    Stage mast       :   0.182
+    Stage mbc        :   0.011
+Stage parse      :   7.564
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Menu ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Menu.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.195
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.046
+    Stage mast       :   0.186
+    Stage mbc        :   0.011
+Stage parse      :   6.601
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::MenuBar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/MenuBar.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.044
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.091
+    Stage mbc        :   0.008
+Stage parse      :   3.310
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::MenuButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/MenuButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.071
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.112
+    Stage mbc        :   0.009
+Stage parse      :   4.385
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::MenuItem ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/MenuItem.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.869
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.041
+    Stage mast       :   0.128
+    Stage mbc        :   0.009
+Stage parse      :   5.198
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::MenuShell ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/MenuShell.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.144
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.116
+    Stage mbc        :   0.009
+Stage parse      :   4.489
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::MenuToolButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/MenuToolButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.034
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.086
+    Stage mbc        :   0.009
+Stage parse      :   3.324
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Notebook ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Notebook.pm6
+    Stage start      :   0.000
+    Stage parse      :   6.865
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.061
+    Stage mast       :   0.208
+    Stage mbc        :   0.017
+Stage parse      :   8.311
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Offscreen ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Offscreen.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.654
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.014
+    Stage mast       :   0.075
+    Stage mbc        :   0.007
+Stage parse      :   2.896
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Orientable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Orientable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.582
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.017
+    Stage mast       :   0.078
+    Stage mbc        :   0.008
+Stage parse      :   3.419
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::Overlay ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Overlay.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.896
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.087
+    Stage mbc        :   0.009
+Stage parse      :   3.151
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::PageSetup ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/PageSetup.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.784
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.047
+    Stage mast       :   0.165
+    Stage mbc        :   0.010
+Stage parse      :   6.163
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Pane ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Pane.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.929
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.028
+    Stage mast       :   0.103
+    Stage mbc        :   0.009
+Stage parse      :   4.225
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::PaperSize ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/PaperSize.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.415
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.155
+    Stage mbc        :   0.010
+Stage parse      :   5.771
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Places ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Places.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.537
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.151
+    Stage mbc        :   0.010
+Stage parse      :   5.893
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Popover ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Popover.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.707
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.141
+    Stage mbc        :   0.010
+Stage parse      :   5.053
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::PrintContext ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/PrintContext.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.856
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.104
+    Stage mbc        :   0.010
+Stage parse      :   4.151
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::PrintJob ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/PrintJob.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.145
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.046
+    Stage mast       :   0.171
+    Stage mbc        :   0.049
+Stage parse      :   6.556
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::PrintOperation ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/PrintOperation.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.509
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.045
+    Stage mast       :   0.168
+    Stage mbc        :   0.019
+Stage parse      :   6.908
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::PrintSettings ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/PrintSettings.pm6
+    Stage start      :   0.000
+    Stage parse      :  10.655
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.082
+    Stage mast       :   0.320
+    Stage mbc        :   0.013
+Stage parse      :  12.255
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.002
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Printer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Printer.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.243
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.141
+    Stage mbc        :   0.010
+Stage parse      :   5.599
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ProgressBar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ProgressBar.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.080
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.104
+    Stage mbc        :   0.009
+Stage parse      :   4.384
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::RadioButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/RadioButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.468
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.104
+    Stage mbc        :   0.009
+Stage parse      :   3.747
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::RadioMenuItem ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/RadioMenuItem.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.489
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.120
+    Stage mbc        :   0.008
+Stage parse      :   3.792
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::RadioToolButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/RadioToolButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.025
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.041
+    Stage mast       :   0.087
+    Stage mbc        :   0.008
+Stage parse      :   3.320
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Range ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Range.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.796
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.043
+    Stage mast       :   0.167
+    Stage mbc        :   0.010
+Stage parse      :   6.175
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::RecentChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/RecentChooser.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.198
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.053
+    Stage mast       :   0.172
+    Stage mbc        :   0.010
+Stage parse      :   6.584
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::RecentChooserMenu ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/RecentChooserMenu.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.793
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.078
+    Stage mbc        :   0.008
+Stage parse      :   3.043
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::RecentFilter ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/RecentFilter.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.860
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.101
+    Stage mbc        :   0.009
+Stage parse      :   4.159
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::RecentInfo ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/RecentInfo.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.832
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.049
+    Stage mast       :   0.183
+    Stage mbc        :   0.010
+Stage parse      :   7.235
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Render ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Render.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.812
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.053
+    Stage mast       :   0.155
+    Stage mbc        :   0.010
+Stage parse      :   5.769
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Revealer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Revealer.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.277
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.028
+    Stage mast       :   0.089
+    Stage mbc        :   0.008
+Stage parse      :   3.552
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Scale ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Scale.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.230
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.115
+    Stage mbc        :   0.011
+Stage parse      :   4.549
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ScaleButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ScaleButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.553
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.094
+    Stage mbc        :   0.009
+Stage parse      :   3.822
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Scrollable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Scrollable.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.568
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.093
+    Stage mbc        :   0.008
+Stage parse      :   3.842
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Scrollbar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Scrollbar.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.433
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.069
+    Stage mbc        :   0.007
+Stage parse      :   2.680
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ScrolledWindow ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ScrolledWindow.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.266
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.052
+    Stage mast       :   0.171
+    Stage mbc        :   0.010
+Stage parse      :   6.664
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::SearchBar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/SearchBar.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.174
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.091
+    Stage mbc        :   0.009
+Stage parse      :   3.435
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::SearchEntry ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/SearchEntry.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.546
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.073
+    Stage mbc        :   0.007
+Stage parse      :   2.765
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Selection ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Selection.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.861
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.053
+    Stage mast       :   0.170
+    Stage mbc        :   0.009
+Stage parse      :   6.247
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Separator ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Separator.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.413
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.067
+    Stage mbc        :   0.007
+Stage parse      :   2.653
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::SeparatorMenuItem ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/SeparatorMenuItem.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.539
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.014
+    Stage mast       :   0.068
+    Stage mbc        :   0.007
+Stage parse      :   2.768
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::SeparatorToolItem ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/SeparatorToolItem.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.681
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.072
+    Stage mbc        :   0.008
+Stage parse      :   2.919
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Settings ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Settings.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.102
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.038
+    Stage mast       :   0.132
+    Stage mbc        :   0.010
+Stage parse      :   4.423
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::SizeGroup ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/SizeGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.285
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.093
+    Stage mbc        :   0.009
+Stage parse      :   3.563
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::SpinButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/SpinButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.328
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.042
+    Stage mast       :   0.156
+    Stage mbc        :   0.010
+Stage parse      :   5.696
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Spinner ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Spinner.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.684
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.075
+    Stage mbc        :   0.008
+Stage parse      :   2.926
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Stack ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Stack.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.296
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.039
+    Stage mast       :   0.166
+    Stage mbc        :   0.010
+Stage parse      :   5.670
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::StackSidebar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/StackSidebar.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.680
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.073
+    Stage mbc        :   0.008
+Stage parse      :   2.920
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::StackSwitcher ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/StackSwitcher.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.668
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.073
+    Stage mbc        :   0.008
+Stage parse      :   2.914
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Statusbar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Statusbar.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.159
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.092
+    Stage mbc        :   0.009
+Stage parse      :   3.429
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::StyleContext ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/StyleContext.pm6
+    Stage start      :   0.000
+    Stage parse      :   9.096
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.071
+    Stage mast       :   0.293
+    Stage mbc        :   0.013
+Stage parse      :  11.294
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Subs ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Subs.pm6
+    Stage start      :   0.000
+    Stage parse      :   5.552
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.180
+    Stage mbc        :   0.010
+Stage parse      :   7.466
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Raw::Switch ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Switch.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.931
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.081
+    Stage mbc        :   0.009
+Stage parse      :   3.212
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TargetEntry ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TargetEntry.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.652
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.083
+    Stage mbc        :   0.008
+Stage parse      :   2.909
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TargetList ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TargetList.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.770
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.102
+    Stage mbc        :   0.010
+Stage parse      :   4.067
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TextBuffer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TextBuffer.pm6
+    Stage start      :   0.000
+    Stage parse      :   8.903
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.103
+    Stage mast       :   0.300
+    Stage mbc        :   0.021
+Stage parse      :  10.509
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TextChildAnchor ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TextChildAnchor.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.682
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.071
+    Stage mbc        :   0.008
+Stage parse      :   2.922
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TextIter ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TextIter.pm6
+    Stage start      :   0.000
+    Stage parse      :  13.064
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.090
+    Stage mast       :   0.351
+    Stage mbc        :   0.014
+Stage parse      :  14.705
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.002
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TextMark ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TextMark.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.174
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.093
+    Stage mbc        :   0.008
+Stage parse      :   3.450
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TextTag ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TextTag.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.997
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.091
+    Stage mbc        :   0.009
+Stage parse      :   3.270
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TextTagTable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TextTagTable.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.122
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.045
+    Stage mast       :   0.084
+    Stage mbc        :   0.009
+Stage parse      :   3.410
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TextView ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TextView.pm6
+    Stage start      :   0.000
+    Stage parse      :  10.976
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.095
+    Stage mast       :   0.311
+    Stage mbc        :   0.013
+Stage parse      :  12.578
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ToggleButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ToggleButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.509
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.107
+    Stage mbc        :   0.008
+Stage parse      :   3.800
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ToggleToolButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ToggleToolButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.787
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.078
+    Stage mbc        :   0.008
+Stage parse      :   3.042
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ToolButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ToolButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.141
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.115
+    Stage mbc        :   0.009
+Stage parse      :   4.465
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ToolItem ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ToolItem.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.778
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.158
+    Stage mbc        :   0.010
+Stage parse      :   6.164
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ToolItemGroup ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ToolItemGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.586
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.138
+    Stage mbc        :   0.009
+Stage parse      :   4.927
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ToolPalette ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ToolPalette.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.033
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.042
+    Stage mast       :   0.140
+    Stage mbc        :   0.010
+Stage parse      :   5.393
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::ToolShell ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/ToolShell.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.493
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.096
+    Stage mbc        :   0.009
+Stage parse      :   3.770
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Toolbar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Toolbar.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.069
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.107
+    Stage mbc        :   0.009
+Stage parse      :   4.398
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::Tooltip ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/Tooltip.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.554
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.028
+    Stage mast       :   0.094
+    Stage mbc        :   0.009
+Stage parse      :   3.862
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TreeDnD ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TreeDnD.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.332
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.091
+    Stage mbc        :   0.009
+Stage parse      :   3.644
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TreeModel ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TreeModel.pm6
+    Stage start      :   0.000
+    Stage parse      :   8.125
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.068
+    Stage mast       :   0.263
+    Stage mbc        :   0.020
+Stage parse      :   9.631
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TreeModelFilter ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TreeModelFilter.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.694
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.085
+    Stage mast       :   0.101
+    Stage mbc        :   0.009
+Stage parse      :   4.058
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TreeModelSort ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TreeModelSort.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.444
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.104
+    Stage mbc        :   0.009
+Stage parse      :   3.739
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TreeSelection ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TreeSelection.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.855
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.042
+    Stage mast       :   0.136
+    Stage mbc        :   0.010
+Stage parse      :   5.212
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TreeSortable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TreeSortable.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.024
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.100
+    Stage mbc        :   0.009
+Stage parse      :   3.299
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TreeStore ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TreeStore.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.880
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.034
+    Stage mast       :   0.181
+    Stage mbc        :   0.009
+Stage parse      :   5.246
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Raw::TreeView ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TreeView.pm6
+    Stage start      :   0.000
+    Stage parse      :  13.881
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.123
+    Stage mast       :   0.413
+    Stage mbc        :   0.019
+Stage parse      :  15.618
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.002
+Stage mast       :   0.005
+Stage mbc        :   0.002
+Stage moar       :   0.000
+ === GTK::Raw::TreeViewColumn ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Raw/TreeViewColumn.pm6
+    Stage start      :   0.000
+    Stage parse      :   7.613
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.068
+    Stage mast       :   0.223
+    Stage mbc        :   0.012
+Stage parse      :   9.100
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Render ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Render.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.576
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.057
+    Stage mast       :   0.197
+    Stage mbc        :   0.018
+Stage parse      :   3.796
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Roles::Actionable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Actionable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.393
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.077
+    Stage mbc        :   0.010
+Stage parse      :   2.690
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::AppChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/AppChooser.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.259
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.017
+    Stage mast       :   0.070
+    Stage mbc        :   0.009
+Stage parse      :   2.508
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Buildable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Buildable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.387
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.091
+    Stage mbc        :   0.005
+Stage parse      :   3.251
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Roles::Data ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Data.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.400
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.095
+    Stage mbc        :   0.007
+Stage parse      :   3.423
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.001
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Roles::Orientable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Orientable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.370
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.077
+    Stage mbc        :   0.005
+Stage parse      :   3.257
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Roles::References ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/References.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.239
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.074
+    Stage mbc        :   0.006
+Stage parse      :   2.500
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::Application ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/Application.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.509
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.017
+    Stage mast       :   0.086
+    Stage mbc        :   0.008
+Stage parse      :   3.419
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Roles::Signals::CSSProvider ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/CSSProvider.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.528
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.017
+    Stage mast       :   0.084
+    Stage mbc        :   0.008
+Stage parse      :   2.795
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::CellArea ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/CellArea.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.265
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.133
+    Stage mbc        :   0.006
+Stage parse      :   3.596
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::CellRenderer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/CellRenderer.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.523
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.088
+    Stage mbc        :   0.008
+Stage parse      :   2.800
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::CellRendererAccel ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/CellRendererAccel.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.538
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.088
+    Stage mbc        :   0.008
+Stage parse      :   2.808
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::ComboBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/ComboBox.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.863
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.102
+    Stage mbc        :   0.008
+Stage parse      :   3.146
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::Editable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/Editable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.746
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.098
+    Stage mbc        :   0.009
+Stage parse      :   3.036
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::Entry ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/Entry.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.527
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.089
+    Stage mbc        :   0.008
+Stage parse      :   2.825
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::EntryCompletion ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/EntryCompletion.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.511
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.087
+    Stage mbc        :   0.008
+Stage parse      :   2.783
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::FlowBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/FlowBox.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.547
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.083
+    Stage mbc        :   0.009
+Stage parse      :   3.395
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Roles::Signals::Generic ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/Generic.pm6
+    Stage start      :   0.000
+    Stage parse      :   7.329
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.148
+    Stage mast       :   0.386
+    Stage mbc        :   0.014
+Stage parse      :   9.715
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Roles::Signals::IconView ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/IconView.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.935
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.114
+    Stage mbc        :   0.009
+Stage parse      :   3.251
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::ListBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/ListBox.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.491
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.083
+    Stage mbc        :   0.008
+Stage parse      :   2.756
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::Menu ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/Menu.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.537
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.087
+    Stage mbc        :   0.008
+Stage parse      :   2.815
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::MenuShell ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/MenuShell.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.656
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.080
+    Stage mbc        :   0.008
+Stage parse      :   2.949
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::Notebook ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/Notebook.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.962
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.122
+    Stage mbc        :   0.009
+Stage parse      :   3.301
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::Overlay ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/Overlay.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.522
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.090
+    Stage mbc        :   0.008
+Stage parse      :   2.789
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::Places ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/Places.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.436
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.042
+    Stage mast       :   0.147
+    Stage mbc        :   0.010
+Stage parse      :   3.791
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::PrintOperation ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/PrintOperation.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.878
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.054
+    Stage mast       :   0.162
+    Stage mbc        :   0.006
+Stage parse      :   4.263
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::Range ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/Range.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.566
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.089
+    Stage mbc        :   0.008
+Stage parse      :   2.841
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::Scale ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/Scale.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.516
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.089
+    Stage mbc        :   0.008
+Stage parse      :   2.792
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::ScrolledWindow ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/ScrolledWindow.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.523
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.087
+    Stage mbc        :   0.008
+Stage parse      :   2.818
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::SpinButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/SpinButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.509
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.088
+    Stage mbc        :   0.008
+Stage parse      :   2.769
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::Statusbar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/Statusbar.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.541
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.090
+    Stage mbc        :   0.008
+Stage parse      :   2.844
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::TextBuffer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/TextBuffer.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.244
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.060
+    Stage mast       :   0.195
+    Stage mbc        :   0.010
+Stage parse      :   4.720
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::TextTag ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/TextTag.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.527
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.082
+    Stage mbc        :   0.008
+Stage parse      :   2.792
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::TextTagTable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/TextTagTable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.710
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.028
+    Stage mast       :   0.095
+    Stage mbc        :   0.009
+Stage parse      :   2.996
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::TextView ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/TextView.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.509
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.089
+    Stage mbc        :   0.008
+Stage parse      :   2.776
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::Toolbar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/Toolbar.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.507
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.087
+    Stage mbc        :   0.008
+Stage parse      :   2.789
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::TreeView ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/TreeView.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.932
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.126
+    Stage mbc        :   0.009
+Stage parse      :   3.249
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Signals::Widget ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Signals/Widget.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.581
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.088
+    Stage mast       :   0.272
+    Stage mbc        :   0.013
+Stage parse      :   6.678
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Roles::TreeDnD ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/TreeDnD.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.360
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.120
+    Stage mbc        :   0.005
+Stage parse      :   2.648
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::TreeSortable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/TreeSortable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.356
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.028
+    Stage mast       :   0.085
+    Stage mbc        :   0.011
+Stage parse      :   2.646
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::TargetEntry ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TargetEntry.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.192
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.112
+    Stage mbc        :   0.013
+Stage parse      :   2.498
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::TreeIter ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TreeIter.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::TreePath ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TreePath.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.425
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.136
+    Stage mbc        :   0.011
+Stage parse      :   2.786
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::TreeRowReference ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TreeRowReference.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.247
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.034
+    Stage mast       :   0.113
+    Stage mbc        :   0.011
+Stage parse      :   2.597
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::WidgetPath ===
+Stage start      :   0.000
+
+    precomp lib/GTK/WidgetPath.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.619
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.056
+    Stage mast       :   0.139
+    Stage mbc        :   0.020
+Stage parse      :   3.048
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.006
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Error ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Error.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.264
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.123
+    Stage mbc        :   0.009
+Stage parse      :   2.574
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.002
+Stage mast       :   0.006
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Roles::Object ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Roles/Object.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.954
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.113
+    Stage mbc        :   0.006
+Stage parse      :   3.295
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::FileAttributeMatcher ===
+Stage start      :   0.000
+
+    precomp lib/GIO/FileAttributeMatcher.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.236
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.089
+    Stage mbc        :   0.006
+Stage parse      :   2.485
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Resource ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Resource.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.378
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.045
+    Stage mast       :   0.154
+    Stage mbc        :   0.010
+Stage parse      :   2.755
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::DatagramBased ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/DatagramBased.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.484
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.103
+    Stage mbc        :   0.007
+Stage parse      :   2.803
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::PollableOutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/PollableOutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.499
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.101
+    Stage mbc        :   0.004
+Stage parse      :   2.798
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Signals::ActionGroup ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Signals/ActionGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.599
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.095
+    Stage mbc        :   0.005
+Stage parse      :   2.898
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Signals::Settings ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Signals/Settings.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.466
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.082
+    Stage mbc        :   0.004
+Stage parse      :   2.725
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::SrvTarget ===
+Stage start      :   0.000
+
+    precomp lib/GIO/SrvTarget.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.480
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.087
+    Stage mbc        :   0.005
+Stage parse      :   2.756
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GLib::ByteArray ===
+Stage start      :   0.000
+
+    precomp lib/GLib/ByteArray.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.364
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.119
+    Stage mbc        :   0.006
+Stage parse      :   2.654
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Cairo ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Cairo.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.362
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.112
+    Stage mbc        :   0.007
+Stage parse      :   2.740
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::DragContext ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/DragContext.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.575
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.046
+    Stage mast       :   0.142
+    Stage mbc        :   0.008
+Stage parse      :   2.960
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::FrameClock ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/FrameClock.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.290
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.129
+    Stage mbc        :   0.009
+Stage parse      :   2.646
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Pixbuf::Animation ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Pixbuf/Animation.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.321
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.102
+    Stage mbc        :   0.008
+Stage parse      :   2.579
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Roles::Object ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Roles/Object.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.416
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.037
+    Stage mast       :   0.077
+    Stage mbc        :   0.007
+Stage parse      :   2.713
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Roles::Signals ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Roles/Signals.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.518
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.087
+    Stage mbc        :   0.009
+Stage parse      :   2.808
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Roles::Signals::Device ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Roles/Signals/Device.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.485
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.017
+    Stage mast       :   0.084
+    Stage mbc        :   0.005
+Stage parse      :   2.769
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Roles::Signals::Settings ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Roles/Signals/Settings.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.498
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.084
+    Stage mbc        :   0.005
+Stage parse      :   2.786
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Screen ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Screen.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.477
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.046
+    Stage mast       :   0.148
+    Stage mbc        :   0.009
+Stage parse      :   2.888
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Value ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Value.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.610
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.065
+    Stage mast       :   0.214
+    Stage mbc        :   0.010
+Stage parse      :   3.101
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::VariantDict ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/VariantDict.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.243
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.034
+    Stage mast       :   0.114
+    Stage mbc        :   0.008
+Stage parse      :   2.600
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::DragContext ===
+Stage start      :   0.000
+
+    precomp lib/GTK/DragContext.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.457
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.125
+    Stage mbc        :   0.010
+Stage parse      :   2.836
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::FileFilter ===
+Stage start      :   0.000
+
+    precomp lib/GTK/FileFilter.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.470
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.155
+    Stage mbc        :   0.011
+Stage parse      :   2.886
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Get ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Get.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.346
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.109
+    Stage mbc        :   0.008
+Stage parse      :   2.653
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::PaperSize ===
+Stage start      :   0.000
+
+    precomp lib/GTK/PaperSize.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.355
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.046
+    Stage mast       :   0.145
+    Stage mbc        :   0.015
+Stage parse      :   2.748
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::PrintSettings ===
+Stage start      :   0.000
+
+    precomp lib/GTK/PrintSettings.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.857
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.082
+    Stage mast       :   0.307
+    Stage mbc        :   0.015
+Stage parse      :   3.465
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::RecentFilter ===
+Stage start      :   0.000
+
+    precomp lib/GTK/RecentFilter.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.310
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.149
+    Stage mbc        :   0.010
+Stage parse      :   2.720
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::RecentInfo ===
+Stage start      :   0.000
+
+    precomp lib/GTK/RecentInfo.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.239
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.042
+    Stage mast       :   0.137
+    Stage mbc        :   0.010
+Stage parse      :   3.649
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::CellEditable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/CellEditable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.423
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.103
+    Stage mbc        :   0.011
+Stage parse      :   2.805
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::ColorChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/ColorChooser.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.367
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.084
+    Stage mbc        :   0.010
+Stage parse      :   2.706
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Editable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Editable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.488
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.037
+    Stage mast       :   0.109
+    Stage mbc        :   0.009
+Stage parse      :   2.848
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::FileChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/FileChooser.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.847
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.072
+    Stage mast       :   0.172
+    Stage mbc        :   0.013
+Stage parse      :   3.387
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::FontChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/FontChooser.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.848
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.114
+    Stage mbc        :   0.008
+Stage parse      :   3.207
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Properties ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Properties.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.564
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.114
+    Stage mast       :   0.111
+    Stage mbc        :   0.007
+Stage parse      :   3.661
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.001
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Roles::RecentChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/RecentChooser.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.937
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.067
+    Stage mast       :   0.144
+    Stage mbc        :   0.009
+Stage parse      :   3.452
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::TreeModel ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/TreeModel.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/TreeIter.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/TreeIter.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Selection ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Selection.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.035
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.147
+    Stage mbc        :   0.038
+Stage parse      :   3.478
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Settings ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Settings.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.702
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.144
+    Stage mast       :   0.422
+    Stage mbc        :   0.020
+Stage parse      :   4.534
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::SizeGroup ===
+Stage start      :   0.000
+
+    precomp lib/GTK/SizeGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.521
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.030
+    Stage mast       :   0.103
+    Stage mbc        :   0.049
+Stage parse      :   2.901
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::StyleContext ===
+Stage start      :   0.000
+
+    precomp lib/GTK/StyleContext.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.811
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.144
+    Stage mast       :   0.426
+    Stage mbc        :   0.018
+Stage parse      :   4.810
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.003
+Stage moar       :   0.000
+ === GTK::TargetList ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TargetList.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.366
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.163
+    Stage mbc        :   0.012
+Stage parse      :   2.781
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::TextChildAnchor ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TextChildAnchor.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.292
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.130
+    Stage mbc        :   0.013
+Stage parse      :   2.669
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::TextMark ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TextMark.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.704
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.099
+    Stage mbc        :   0.009
+Stage parse      :   3.065
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::TextTag ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TextTag.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.709
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.130
+    Stage mast       :   0.433
+    Stage mbc        :   0.021
+Stage parse      :   4.589
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::TextTagTable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TextTagTable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.562
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.130
+    Stage mbc        :   0.009
+Stage parse      :   3.084
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.004
+Stage moar       :   0.000
+ === GTK::Tooltip ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Tooltip.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.279
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.146
+    Stage mbc        :   0.013
+Stage parse      :   2.659
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::TreeModelFilter ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TreeModelFilter.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Roles/TreeModel.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/TreeIter.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/TreeIter.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/TreeModel.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/TreeIter.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/TreeIter.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::TreeModelSort ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TreeModelSort.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Roles/TreeModel.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/TreeIter.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/TreeIter.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/TreeModel.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/TreeIter.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/TreeIter.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::TreeSelection ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TreeSelection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.489
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.157
+    Stage mbc        :   0.010
+Stage parse      :   2.922
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::TreeStore ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TreeStore.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Roles/TreeModel.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/TreeIter.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/TreeIter.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/TreeModel.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/TreeIter.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/TreeIter.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::WindowGroup ===
+Stage start      :   0.000
+
+    precomp lib/GTK/WindowGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.273
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.118
+    Stage mbc        :   0.016
+Stage parse      :   2.658
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Cancellable ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Cancellable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.371
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.145
+    Stage mbc        :   0.008
+Stage parse      :   2.815
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::CharsetConverter ===
+Stage start      :   0.000
+
+    precomp lib/GIO/CharsetConverter.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.419
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.111
+    Stage mbc        :   0.007
+Stage parse      :   2.811
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Credentials ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Credentials.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.337
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.099
+    Stage mbc        :   0.006
+Stage parse      :   2.672
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::ActionGroup ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/ActionGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.528
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.107
+    Stage mbc        :   0.006
+Stage parse      :   2.893
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::AuthObserver ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/AuthObserver.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.715
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.098
+    Stage mbc        :   0.006
+Stage parse      :   3.042
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::InterfaceSkeleton ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/InterfaceSkeleton.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.739
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.034
+    Stage mast       :   0.126
+    Stage mbc        :   0.006
+Stage parse      :   3.200
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::ObjectSkeleton ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/ObjectSkeleton.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.476
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.128
+    Stage mbc        :   0.007
+Stage parse      :   2.955
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Proxy ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Proxy.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.708
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.117
+    Stage mast       :   0.325
+    Stage mbc        :   0.013
+Stage parse      :   4.501
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Server ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Server.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.679
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.118
+    Stage mbc        :   0.007
+Stage parse      :   3.157
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Emblem ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Emblem.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.466
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.017
+    Stage mast       :   0.100
+    Stage mbc        :   0.006
+Stage parse      :   2.850
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::EmblemedIcon ===
+Stage start      :   0.000
+
+    precomp lib/GIO/EmblemedIcon.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.539
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.017
+    Stage mast       :   0.119
+    Stage mbc        :   0.006
+Stage parse      :   3.024
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::FileInfo ===
+Stage start      :   0.000
+
+    precomp lib/GIO/FileInfo.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.610
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.067
+    Stage mast       :   0.229
+    Stage mbc        :   0.013
+Stage parse      :   3.141
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::FileMonitor ===
+Stage start      :   0.000
+
+    precomp lib/GIO/FileMonitor.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.311
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.124
+    Stage mbc        :   0.007
+Stage parse      :   2.715
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::FilenameCompleter ===
+Stage start      :   0.000
+
+    precomp lib/GIO/FilenameCompleter.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.245
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.103
+    Stage mbc        :   0.007
+Stage parse      :   2.567
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::InetAddress ===
+Stage start      :   0.000
+
+    precomp lib/GIO/InetAddress.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.923
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.139
+    Stage mbc        :   0.006
+Stage parse      :   3.312
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::InetAddressMask ===
+Stage start      :   0.000
+
+    precomp lib/GIO/InetAddressMask.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.537
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.100
+    Stage mbc        :   0.005
+Stage parse      :   2.882
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::InputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/InputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.580
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.045
+    Stage mast       :   0.197
+    Stage mbc        :   0.009
+Stage parse      :   3.029
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.009
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::ListStore ===
+Stage start      :   0.000
+
+    precomp lib/GIO/ListStore.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.281
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.126
+    Stage mbc        :   0.007
+Stage parse      :   2.658
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::MemoryInputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/MemoryInputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.378
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.143
+    Stage mbc        :   0.007
+Stage parse      :   2.816
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::MountOperation ===
+Stage start      :   0.000
+
+    precomp lib/GIO/MountOperation.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.467
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.034
+    Stage mast       :   0.146
+    Stage mbc        :   0.008
+Stage parse      :   2.840
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Notification ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Notification.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GIO/Notification.pm6 (GIO::Notification)
+    Two terms in a row across lines (missing semicolon or comma?)
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GIO/Notification.pm6 (GIO::Notification):19
+    ------> [32m    $!n = $notification[33m⏏[31m<EOL>[0m
+        expecting any of:
+            infix
+            infix stopper
+            statement end
+            statement modifier
+            statement modifier loop
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GIO/Notification.pm6 (GIO::Notification)
+Two terms in a row across lines (missing semicolon or comma?)
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GIO/Notification.pm6 (GIO::Notification):19
+------> [32m    $!n = $notification[33m⏏[31m<EOL>[0m
+    expecting any of:
+        infix
+        infix stopper
+        statement end
+        statement modifier
+        statement modifier loop
+ === GIO::OutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/OutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.519
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.062
+    Stage mast       :   0.207
+    Stage mbc        :   0.010
+Stage parse      :   2.992
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Permission ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Permission.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.656
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.114
+    Stage mbc        :   0.006
+Stage parse      :   2.996
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Resolver ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Resolver.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.715
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.075
+    Stage mast       :   0.179
+    Stage mbc        :   0.009
+Stage parse      :   3.255
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Action ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Action.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.658
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.095
+    Stage mbc        :   0.006
+Stage parse      :   3.034
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::AppInfo ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/AppInfo.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.013
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.056
+    Stage mast       :   0.189
+    Stage mbc        :   0.009
+Stage parse      :   3.503
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::DTlsServerConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/DTlsServerConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.603
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.103
+    Stage mbc        :   0.006
+Stage parse      :   2.946
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.004
+Stage moar       :   0.000
+ === GIO::Roles::ListModel ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/ListModel.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.518
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.091
+    Stage mbc        :   0.006
+Stage parse      :   2.838
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::LoadableIcon ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/LoadableIcon.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.927
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.065
+    Stage mast       :   0.120
+    Stage mbc        :   0.004
+Stage parse      :   3.356
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::TlsFileDatabase ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/TlsFileDatabase.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.585
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.091
+    Stage mbc        :   0.005
+Stage parse      :   2.918
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::TlsServerConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/TlsServerConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.598
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.103
+    Stage mbc        :   0.006
+Stage parse      :   2.940
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.007
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Settings ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Settings.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.836
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.078
+    Stage mast       :   0.251
+    Stage mbc        :   0.013
+Stage parse      :   3.466
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::SettingsBackend ===
+Stage start      :   0.000
+
+    precomp lib/GIO/SettingsBackend.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.449
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.036
+    Stage mast       :   0.126
+    Stage mbc        :   0.007
+Stage parse      :   2.816
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::SimpleAction ===
+Stage start      :   0.000
+
+    precomp lib/GIO/SimpleAction.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.353
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   : [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GIO/SimpleAction.pm6 (GIO::SimpleAction)
+    No such private method '!roleInit-Object' for invocant of type 'GTK::Compat::SimpleAction'. Did you mean 'roleInit-Object'?
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GIO/SimpleAction.pm6 (GIO::SimpleAction):23
+    ------> [32m    self![33m⏏[31mroleInit-Object;[0m
+Stage start      :   0.000
+Stage parse      :   1.353
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   : [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GIO/SimpleAction.pm6 (GIO::SimpleAction)
+No such private method '!roleInit-Object' for invocant of type 'GTK::Compat::SimpleAction'. Did you mean 'roleInit-Object'?
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GIO/SimpleAction.pm6 (GIO::SimpleAction):23
+------> [32m    self![33m⏏[31mroleInit-Object;[0m
+ === GIO::SimpleActionGroup ===
+Stage start      :   0.000
+
+    precomp lib/GIO/SimpleActionGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.538
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.015
+    Stage mast       :   0.112
+    Stage mbc        :   0.006
+Stage parse      :   2.902
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::SimplePermission ===
+Stage start      :   0.000
+
+    precomp lib/GIO/SimplePermission.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.621
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.098
+    Stage mbc        :   0.006
+Stage parse      :   2.962
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::SimpleProxyResolver ===
+Stage start      :   0.000
+
+    precomp lib/GIO/SimpleProxyResolver.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.348
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.028
+    Stage mast       :   0.128
+    Stage mbc        :   0.007
+Stage parse      :   2.768
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::SocketAddressEnumerator ===
+Stage start      :   0.000
+
+    precomp lib/GIO/SocketAddressEnumerator.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.677
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.099
+    Stage mbc        :   0.006
+Stage parse      :   2.993
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::SocketControlMessage ===
+Stage start      :   0.000
+
+    precomp lib/GIO/SocketControlMessage.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.434
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.092
+    Stage mbc        :   0.006
+Stage parse      :   2.747
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Stream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Stream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.427
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.152
+    Stage mbc        :   0.008
+Stage parse      :   2.910
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Task ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Task.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.847
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.054
+    Stage mast       :   0.220
+    Stage mbc        :   0.008
+Stage parse      :   3.445
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::ThemedIcon ===
+Stage start      :   0.000
+
+    precomp lib/GIO/ThemedIcon.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.455
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.115
+    Stage mbc        :   0.007
+Stage parse      :   2.865
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::TlsCertificate ===
+Stage start      :   0.000
+
+    precomp lib/GIO/TlsCertificate.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.642
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.173
+    Stage mbc        :   0.010
+Stage parse      :   3.173
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::TlsDatabase ===
+Stage start      :   0.000
+
+    precomp lib/GIO/TlsDatabase.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.582
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.048
+    Stage mast       :   0.205
+    Stage mbc        :   0.010
+Stage parse      :   3.201
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::TlsInteraction ===
+Stage start      :   0.000
+
+    precomp lib/GIO/TlsInteraction.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.461
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.137
+    Stage mbc        :   0.009
+Stage parse      :   2.853
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::TlsPassword ===
+Stage start      :   0.000
+
+    precomp lib/GIO/TlsPassword.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.284
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.128
+    Stage mbc        :   0.009
+Stage parse      :   2.648
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::UnixCredentialsMessage ===
+Stage start      :   0.000
+
+    precomp lib/GIO/UnixCredentialsMessage.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.391
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.108
+    Stage mbc        :   0.007
+Stage parse      :   2.767
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::UnixFDList ===
+Stage start      :   0.000
+
+    precomp lib/GIO/UnixFDList.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.285
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.123
+    Stage mbc        :   0.008
+Stage parse      :   2.636
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::UnixFDMessage ===
+Stage start      :   0.000
+
+    precomp lib/GIO/UnixFDMessage.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.334
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.132
+    Stage mbc        :   0.007
+Stage parse      :   2.739
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::UnixInputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/UnixInputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.442
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.125
+    Stage mbc        :   0.007
+Stage parse      :   2.850
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::UnixMount ===
+Stage start      :   0.000
+
+    precomp lib/GIO/UnixMount.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.170
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.059
+    Stage mast       :   0.218
+    Stage mbc        :   0.008
+Stage parse      :   3.728
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::UnixOutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/UnixOutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.376
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.132
+    Stage mbc        :   0.008
+Stage parse      :   2.861
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::VFS ===
+Stage start      :   0.000
+
+    precomp lib/GIO/VFS.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.384
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.103
+    Stage mbc        :   0.006
+Stage parse      :   2.709
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::ZlibCompressor ===
+Stage start      :   0.000
+
+    precomp lib/GIO/ZlibCompressor.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.766
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.114
+    Stage mbc        :   0.006
+Stage parse      :   3.148
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::ZlibDecompressor ===
+Stage start      :   0.000
+
+    precomp lib/GIO/ZlibDecompressor.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.670
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.114
+    Stage mbc        :   0.005
+Stage parse      :   3.113
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::AccelGroup ===
+Stage start      :   0.000
+
+    precomp lib/GTK/AccelGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.411
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.036
+    Stage mast       :   0.157
+    Stage mbc        :   0.013
+Stage parse      :   2.834
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Adjustment ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Adjustment.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.352
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.032
+    Stage mast       :   0.143
+    Stage mbc        :   0.014
+Stage parse      :   2.739
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::CSSProvider ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CSSProvider.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.486
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.036
+    Stage mast       :   0.185
+    Stage mbc        :   0.012
+Stage parse      :   3.040
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::CSS_Section ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CSS_Section.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/CSS_Section.pm6 (GTK::CSS_Section)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/CSS_Section.pm6 (GTK::CSS_Section):11
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/CSS_Section.pm6 (GTK::CSS_Section)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/CSS_Section.pm6 (GTK::CSS_Section):11
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::CellAreaContext ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CellAreaContext.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.449
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.037
+    Stage mast       :   0.163
+    Stage mbc        :   0.016
+Stage parse      :   2.899
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::CellRenderer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CellRenderer.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.749
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.083
+    Stage mast       :   0.243
+    Stage mbc        :   0.013
+Stage parse      :   3.362
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::CellRendererPixbuf ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CellRendererPixbuf.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.614
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.045
+    Stage mast       :   0.193
+    Stage mbc        :   0.014
+Stage parse      :   3.158
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::CellRendererProgress ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CellRendererProgress.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.544
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.160
+    Stage mbc        :   0.022
+Stage parse      :   3.074
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::CellRendererSpinner ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CellRendererSpinner.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.390
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.154
+    Stage mbc        :   0.011
+Stage parse      :   2.886
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::CellRendererText ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CellRendererText.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.114
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.099
+    Stage mast       :   0.342
+    Stage mbc        :   0.018
+Stage parse      :   3.899
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::CellRendererToggle ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CellRendererToggle.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.461
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.036
+    Stage mast       :   0.196
+    Stage mbc        :   0.012
+Stage parse      :   3.012
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Clipboard ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Clipboard.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.493
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.050
+    Stage mast       :   0.182
+    Stage mbc        :   0.012
+Stage parse      :   2.987
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Binding ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Binding.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.264
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.036
+    Stage mast       :   0.113
+    Stage mbc        :   0.007
+Stage parse      :   2.618
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Device ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Device.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.751
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.073
+    Stage mast       :   0.256
+    Stage mbc        :   0.012
+Stage parse      :   3.386
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Display ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Display.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.609
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.050
+    Stage mast       :   0.206
+    Stage mbc        :   0.011
+Stage parse      :   3.183
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::DisplayManager ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/DisplayManager.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.454
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.161
+    Stage mbc        :   0.007
+Stage parse      :   2.922
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Event ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Event.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Compat/Event.pm6 (GTK::Compat::Event)
+    Package 'GTK::Compat::Event' already has a method 'window' (did you mean to declare a multi-method?)
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Compat/Event.pm6 (GTK::Compat::Event):14
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Compat/Event.pm6 (GTK::Compat::Event)
+Package 'GTK::Compat::Event' already has a method 'window' (did you mean to declare a multi-method?)
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Compat/Event.pm6 (GTK::Compat::Event):14
+ === GTK::Compat::HashTable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/HashTable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.563
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.058
+    Stage mast       :   0.185
+    Stage mbc        :   0.010
+Stage parse      :   3.021
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::MenuModel ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/MenuModel.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.354
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.034
+    Stage mast       :   0.132
+    Stage mbc        :   0.008
+Stage parse      :   2.808
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Pixbuf ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Pixbuf.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.514
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.111
+    Stage mast       :   0.326
+    Stage mbc        :   0.010
+Stage parse      :   4.227
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Raw::Monitor ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Raw/Monitor.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.416
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.101
+    Stage mbc        :   0.006
+Stage parse      :   3.746
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Roles::GFile ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Roles/GFile.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.642
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.220
+    Stage mast       :   0.367
+    Stage mbc        :   0.017
+Stage parse      :   5.493
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.005
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Seat ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Seat.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.732
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.130
+    Stage mbc        :   0.015
+Stage parse      :   3.271
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::EntryBuffer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/EntryBuffer.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.428
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.036
+    Stage mast       :   0.162
+    Stage mbc        :   0.012
+Stage parse      :   2.901
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::IconInfo ===
+Stage start      :   0.000
+
+    precomp lib/GTK/IconInfo.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.969
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.050
+    Stage mast       :   0.172
+    Stage mbc        :   0.010
+Stage parse      :   3.515
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::IconTheme ===
+Stage start      :   0.000
+
+    precomp lib/GTK/IconTheme.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.568
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.043
+    Stage mast       :   0.230
+    Stage mbc        :   0.011
+Stage parse      :   3.194
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::ListStore ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ListStore.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Roles/TreeModel.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/TreeIter.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/TreeIter.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/TreeModel.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/TreeIter.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/TreeIter.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::PageSetup ===
+Stage start      :   0.000
+
+    precomp lib/GTK/PageSetup.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.535
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.050
+    Stage mast       :   0.187
+    Stage mbc        :   0.015
+Stage parse      :   3.039
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::PrintContext ===
+Stage start      :   0.000
+
+    precomp lib/GTK/PrintContext.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.659
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.044
+    Stage mast       :   0.148
+    Stage mbc        :   0.010
+Stage parse      :   3.185
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::PrintJob ===
+Stage start      :   0.000
+
+    precomp lib/GTK/PrintJob.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.710
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.056
+    Stage mast       :   0.211
+    Stage mbc        :   0.011
+Stage parse      :   3.256
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::PrintOperation ===
+Stage start      :   0.000
+
+    precomp lib/GTK/PrintOperation.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.086
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.073
+    Stage mast       :   0.270
+    Stage mbc        :   0.013
+Stage parse      :   3.855
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Printer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Printer.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.557
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.050
+    Stage mast       :   0.192
+    Stage mbc        :   0.012
+Stage parse      :   3.086
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::RecentManager ===
+Stage start      :   0.000
+
+    precomp lib/GTK/RecentManager.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.524
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.037
+    Stage mast       :   0.164
+    Stage mbc        :   0.012
+Stage parse      :   3.006
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::Scrollable ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/Scrollable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.544
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.106
+    Stage mbc        :   0.006
+Stage parse      :   2.903
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::ToolShell ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/ToolShell.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.787
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.064
+    Stage mast       :   0.090
+    Stage mbc        :   0.009
+Stage parse      :   3.171
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::TextIter ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TextIter.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.468
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.094
+    Stage mast       :   0.307
+    Stage mbc        :   0.012
+Stage parse      :   4.278
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::BytesIcon ===
+Stage start      :   0.000
+
+    precomp lib/GIO/BytesIcon.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.770
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.126
+    Stage mbc        :   0.006
+Stage parse      :   3.217
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Address ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Address.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.425
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.153
+    Stage mbc        :   0.008
+Stage parse      :   2.966
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Message ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Message.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.728
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.070
+    Stage mast       :   0.263
+    Stage mbc        :   0.012
+Stage parse      :   3.351
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DesktopAppInfo ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DesktopAppInfo.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.499
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.042
+    Stage mast       :   0.228
+    Stage mbc        :   0.009
+Stage parse      :   3.040
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::FileAttributeInfoList ===
+Stage start      :   0.000
+
+    precomp lib/GIO/FileAttributeInfoList.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.310
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.017
+    Stage mast       :   0.119
+    Stage mbc        :   0.009
+Stage parse      :   2.700
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::FileEnumerator ===
+Stage start      :   0.000
+
+    precomp lib/GIO/FileEnumerator.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.538
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.039
+    Stage mast       :   0.155
+    Stage mbc        :   0.020
+Stage parse      :   3.030
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::FileIOStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/FileIOStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.484
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.161
+    Stage mbc        :   0.008
+Stage parse      :   3.072
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::FileIcon ===
+Stage start      :   0.000
+
+    precomp lib/GIO/FileIcon.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.775
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.133
+    Stage mbc        :   0.007
+Stage parse      :   3.252
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::FilterInputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/FilterInputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.350
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.039
+    Stage mast       :   0.101
+    Stage mbc        :   0.006
+Stage parse      :   2.720
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::FilterOutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/FilterOutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.345
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.105
+    Stage mbc        :   0.006
+Stage parse      :   2.694
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::MemoryOutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/MemoryOutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.400
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.150
+    Stage mbc        :   0.008
+Stage parse      :   2.892
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::PropertyAction ===
+Stage start      :   0.000
+
+    precomp lib/GIO/PropertyAction.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.678
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.134
+    Stage mbc        :   0.007
+Stage parse      :   3.116
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::DtlsConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/DtlsConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.293
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.069
+    Stage mast       :   0.201
+    Stage mbc        :   0.007
+Stage parse      :   4.090
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Proxy ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Proxy.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.450
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.114
+    Stage mbc        :   0.007
+Stage parse      :   2.940
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::SocketConnectable ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/SocketConnectable.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.854
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.099
+    Stage mbc        :   0.006
+Stage parse      :   3.169
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::TlsBackend ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/TlsBackend.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.535
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.133
+    Stage mbc        :   0.007
+Stage parse      :   3.108
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::TlsClientConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/TlsClientConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.670
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.131
+    Stage mbc        :   0.008
+Stage parse      :   3.135
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Volume ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Volume.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.761
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.152
+    Stage mbc        :   0.008
+Stage parse      :   3.281
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::SocketAddress ===
+Stage start      :   0.000
+
+    precomp lib/GIO/SocketAddress.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.551
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.102
+    Stage mbc        :   0.006
+Stage parse      :   2.934
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::TlsConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/TlsConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.903
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.231
+    Stage mbc        :   0.008
+Stage parse      :   3.666
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::UnixSocketAddress ===
+Stage start      :   0.000
+
+    precomp lib/GIO/UnixSocketAddress.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.550
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.105
+    Stage mbc        :   0.006
+Stage parse      :   2.925
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::CellRendererAccel ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CellRendererAccel.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.473
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.036
+    Stage mast       :   0.197
+    Stage mbc        :   0.010
+Stage parse      :   3.066
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::CellRendererSpin ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CellRendererSpin.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.626
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.168
+    Stage mbc        :   0.014
+Stage parse      :   3.213
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::AppLaunchContext ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/AppLaunchContext.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.402
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.019
+    Stage mast       :   0.141
+    Stage mbc        :   0.007
+Stage parse      :   2.898
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Cursor ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Cursor.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.446
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.171
+    Stage mbc        :   0.007
+Stage parse      :   3.025
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Menu ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Menu.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.454
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.156
+    Stage mbc        :   0.008
+Stage parse      :   2.931
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Monitor ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Monitor.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.609
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.041
+    Stage mast       :   0.179
+    Stage mbc        :   0.009
+Stage parse      :   3.117
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Compat::Window ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Compat/Window.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.754
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.291
+    Stage mast       :   0.466
+    Stage mbc        :   0.016
+Stage parse      :   5.004
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::TextBuffer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TextBuffer.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.904
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.268
+    Stage mast       :   0.457
+    Stage mbc        :   0.015
+Stage parse      :   5.277
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Widget ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Widget.pm6
+    Stage start      :   0.000
+    Stage parse      :   4.561
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.254
+    Stage mast       :   0.660
+    Stage mbc        :   0.025
+Stage parse      :   7.317
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::BufferedInputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/BufferedInputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.628
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.145
+    Stage mbc        :   0.007
+Stage parse      :   3.092
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::BufferedOutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/BufferedOutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.352
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.143
+    Stage mbc        :   0.007
+Stage parse      :   2.788
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::ConverterInputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/ConverterInputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.725
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.122
+    Stage mbc        :   0.006
+Stage parse      :   3.165
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::ConverterOutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/ConverterOutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.863
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.030
+    Stage mast       :   0.136
+    Stage mbc        :   0.006
+Stage parse      :   3.370
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::Connection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/Connection.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.820
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.146
+    Stage mast       :   0.437
+    Stage mbc        :   0.012
+Stage parse      :   4.836
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::MethodInvocation ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/MethodInvocation.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.037
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.153
+    Stage mbc        :   0.008
+Stage parse      :   3.632
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::ObjectManagerClient ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/ObjectManagerClient.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.943
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.071
+    Stage mast       :   0.205
+    Stage mbc        :   0.008
+Stage parse      :   3.647
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::ObjectManagerServer ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/ObjectManagerServer.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.482
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.017
+    Stage mast       :   0.138
+    Stage mbc        :   0.007
+Stage parse      :   3.063
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DBus::ObjectProxy ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DBus/ObjectProxy.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.894
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.029
+    Stage mast       :   0.142
+    Stage mbc        :   0.006
+Stage parse      :   3.485
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::DataInputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DataInputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.608
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.058
+    Stage mast       :   0.204
+    Stage mbc        :   0.010
+Stage parse      :   3.169
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.004
+Stage moar       :   0.000
+ === GIO::DataOutputStream ===
+Stage start      :   0.000
+
+    precomp lib/GIO/DataOutputStream.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.395
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.036
+    Stage mast       :   0.174
+    Stage mbc        :   0.010
+Stage parse      :   2.893
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::InetSocketAddress ===
+Stage start      :   0.000
+
+    precomp lib/GIO/InetSocketAddress.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.718
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.102
+    Stage mbc        :   0.005
+Stage parse      :   3.108
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::NetworkAddress ===
+Stage start      :   0.000
+
+    precomp lib/GIO/NetworkAddress.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.601
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.108
+    Stage mbc        :   0.005
+Stage parse      :   2.959
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::NetworkService ===
+Stage start      :   0.000
+
+    precomp lib/GIO/NetworkService.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.462
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.097
+    Stage mbc        :   0.005
+Stage parse      :   2.793
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::ProxyAddress ===
+Stage start      :   0.000
+
+    precomp lib/GIO/ProxyAddress.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.733
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.025
+    Stage mast       :   0.110
+    Stage mbc        :   0.005
+Stage parse      :   3.214
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::ProxyAddressEnumerator ===
+Stage start      :   0.000
+
+    precomp lib/GIO/ProxyAddressEnumerator.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.488
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.129
+    Stage mbc        :   0.007
+Stage parse      :   2.932
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::DTlsClientConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/DTlsClientConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.724
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.144
+    Stage mbc        :   0.005
+Stage parse      :   3.205
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Drive ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Drive.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.913
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.050
+    Stage mast       :   0.172
+    Stage mbc        :   0.009
+Stage parse      :   3.495
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Roles::Mount ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Roles/Mount.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.799
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.078
+    Stage mast       :   0.169
+    Stage mbc        :   0.008
+Stage parse      :   3.410
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::Socket ===
+Stage start      :   0.000
+
+    precomp lib/GIO/Socket.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.320
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.123
+    Stage mast       :   0.256
+    Stage mbc        :   0.009
+Stage parse      :   4.045
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::SocketConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/SocketConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.597
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.197
+    Stage mbc        :   0.008
+Stage parse      :   3.310
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::SocketListener ===
+Stage start      :   0.000
+
+    precomp lib/GIO/SocketListener.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.687
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.038
+    Stage mast       :   0.210
+    Stage mbc        :   0.008
+Stage parse      :   3.458
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::SocketService ===
+Stage start      :   0.000
+
+    precomp lib/GIO/SocketService.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.581
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.018
+    Stage mast       :   0.193
+    Stage mbc        :   0.008
+Stage parse      :   3.355
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.007
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::TcpConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/TcpConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.881
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.026
+    Stage mast       :   0.155
+    Stage mbc        :   0.005
+Stage parse      :   3.600
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::TcpWrapperConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/TcpWrapperConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.913
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.022
+    Stage mast       :   0.168
+    Stage mbc        :   0.006
+Stage parse      :   3.639
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::ThreadedSocketService ===
+Stage start      :   0.000
+
+    precomp lib/GIO/ThreadedSocketService.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.842
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.016
+    Stage mast       :   0.162
+    Stage mbc        :   0.005
+Stage parse      :   3.610
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::UnixConnection ===
+Stage start      :   0.000
+
+    precomp lib/GIO/UnixConnection.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.643
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.034
+    Stage mast       :   0.198
+    Stage mbc        :   0.008
+Stage parse      :   3.428
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::VolumeMonitor ===
+Stage start      :   0.000
+
+    precomp lib/GIO/VolumeMonitor.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.754
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.157
+    Stage mbc        :   0.007
+Stage parse      :   3.369
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Calendar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Calendar.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.072
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.037
+    Stage mast       :   0.268
+    Stage mbc        :   0.012
+Stage parse      :   4.220
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::DrawingArea ===
+Stage start      :   0.000
+
+    precomp lib/GTK/DrawingArea.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.272
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.236
+    Stage mbc        :   0.009
+Stage parse      :   4.365
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Entry ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Entry.pm6
+    Stage start      :   0.000
+    Stage parse      :   3.061
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.139
+    Stage mast       :   0.527
+    Stage mbc        :   0.016
+Stage parse      :   5.715
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Image ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Image.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.538
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.063
+    Stage mast       :   0.324
+    Stage mbc        :   0.012
+Stage parse      :   4.802
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.008
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Label ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Label.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.471
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.063
+    Stage mast       :   0.336
+    Stage mbc        :   0.012
+Stage parse      :   4.776
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::LevelBar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/LevelBar.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.984
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.034
+    Stage mast       :   0.278
+    Stage mbc        :   0.011
+Stage parse      :   4.195
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::ProgressBar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ProgressBar.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.989
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.038
+    Stage mast       :   0.299
+    Stage mbc        :   0.012
+Stage parse      :   4.245
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Range ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Range.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.374
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.055
+    Stage mast       :   0.310
+    Stage mbc        :   0.011
+Stage parse      :   4.642
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.009
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::LatchedContents ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/LatchedContents.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.955
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.021
+    Stage mast       :   0.225
+    Stage mbc        :   0.007
+Stage parse      :   4.768
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.001
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Scale ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Scale.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.246
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.047
+    Stage mast       :   0.305
+    Stage mbc        :   0.011
+Stage parse      :   4.584
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Scrollbar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Scrollbar.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.085
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.020
+    Stage mast       :   0.259
+    Stage mbc        :   0.011
+Stage parse      :   4.355
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::SearchEntry ===
+Stage start      :   0.000
+
+    precomp lib/GTK/SearchEntry.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.134
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.270
+    Stage mbc        :   0.013
+Stage parse      :   4.477
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Separator ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Separator.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.048
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.033
+    Stage mast       :   0.278
+    Stage mbc        :   0.012
+Stage parse      :   4.245
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::SpinButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/SpinButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.439
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.046
+    Stage mast       :   0.358
+    Stage mbc        :   0.014
+Stage parse      :   4.941
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Spinner ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Spinner.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.852
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.030
+    Stage mast       :   0.243
+    Stage mbc        :   0.011
+Stage parse      :   3.994
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Switch ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Switch.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.048
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.030
+    Stage mast       :   0.270
+    Stage mbc        :   0.011
+Stage parse      :   4.231
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GIO::SocketClient ===
+Stage start      :   0.000
+
+    precomp lib/GIO/SocketClient.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.866
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.052
+    Stage mast       :   0.252
+    Stage mbc        :   0.010
+Stage parse      :   3.740
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::AccelLabel ===
+Stage start      :   0.000
+
+    precomp lib/GTK/AccelLabel.pm6
+    Stage start      :   0.000
+    Stage parse      :   1.975
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.269
+    Stage mbc        :   0.012
+Stage parse      :   4.220
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.002
+Stage mast       :   0.006
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Container ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Container.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.315
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.067
+    Stage mast       :   0.360
+    Stage mbc        :   0.013
+Stage parse      :   5.348
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.000
+Stage mast       :   0.002
+Stage mbc        :   0.000
+Stage moar       :   0.000
+ === GTK::Fixed ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Fixed.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.026
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.023
+    Stage mast       :   0.281
+    Stage mbc        :   0.013
+Stage parse      :   4.331
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Grid ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Grid.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.362
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.076
+    Stage mast       :   0.387
+    Stage mbc        :   0.014
+Stage parse      :   4.857
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::HeaderBar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/HeaderBar.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.220
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.039
+    Stage mast       :   0.306
+    Stage mbc        :   0.013
+Stage parse      :   4.570
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Layout ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Layout.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.261
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.039
+    Stage mast       :   0.302
+    Stage mbc        :   0.012
+Stage parse      :   4.601
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Notebook ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Notebook.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.772
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.080
+    Stage mast       :   0.364
+    Stage mbc        :   0.013
+Stage parse      :   5.321
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Pane ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Pane.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.487
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.044
+    Stage mast       :   0.324
+    Stage mbc        :   0.010
+Stage parse      :   4.868
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Roles::CellLayout ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Roles/CellLayout.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.206
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.034
+    Stage mast       :   0.233
+    Stage mbc        :   0.006
+Stage parse      :   4.419
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::TextView ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TextView.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.967
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.098
+    Stage mast       :   0.465
+    Stage mbc        :   0.015
+Stage parse      :   5.896
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::ToolItemGroup ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ToolItemGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.347
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.291
+    Stage mbc        :   0.011
+Stage parse      :   4.701
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Toolbar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Toolbar.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.747
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.042
+    Stage mast       :   0.297
+    Stage mbc        :   0.009
+Stage parse      :   5.115
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Bin ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Box ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Box.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.295
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.058
+    Stage mast       :   0.339
+    Stage mbc        :   0.012
+Stage parse      :   4.733
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.006
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Button ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Button.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ButtonBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ButtonBox.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.129
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.031
+    Stage mast       :   0.303
+    Stage mbc        :   0.013
+Stage parse      :   4.549
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::CellArea ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CellArea.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.349
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.081
+    Stage mast       :   0.349
+    Stage mbc        :   0.013
+Stage parse      :   4.847
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::CellAreaBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CellAreaBox.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.134
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.035
+    Stage mast       :   0.272
+    Stage mbc        :   0.011
+Stage parse      :   4.551
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::CellView ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CellView.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.397
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.048
+    Stage mast       :   0.332
+    Stage mbc        :   0.012
+Stage parse      :   4.837
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::ColorButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ColorButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Button.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Button.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ColorChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ColorChooser.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.270
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.024
+    Stage mast       :   0.276
+    Stage mbc        :   0.011
+Stage parse      :   4.690
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::ComboBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ComboBox.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ComboBoxText ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ComboBoxText.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ComboBox.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ComboBox.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::EntryCompletion ===
+Stage start      :   0.000
+
+    precomp lib/GTK/EntryCompletion.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.154
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.051
+    Stage mast       :   0.297
+    Stage mbc        :   0.012
+Stage parse      :   4.513
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::EventBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/EventBox.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Expander ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Expander.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::FileChooserButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/FileChooserButton.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.203
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.028
+    Stage mast       :   0.294
+    Stage mbc        :   0.012
+Stage parse      :   4.688
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::FlowBoxChild ===
+Stage start      :   0.000
+
+    precomp lib/GTK/FlowBoxChild.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::FontButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/FontButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Button.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Button.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Frame ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Frame.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::IconView ===
+Stage start      :   0.000
+
+    precomp lib/GTK/IconView.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.988
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.103
+    Stage mast       :   0.462
+    Stage mbc        :   0.016
+Stage parse      :   5.807
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::InfoBar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/InfoBar.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.379
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.040
+    Stage mast       :   0.287
+    Stage mbc        :   0.011
+Stage parse      :   4.794
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::LinkButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/LinkButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Button.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Button.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ListBoxRow ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ListBoxRow.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::LockButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/LockButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Button.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Button.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::MenuItem ===
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::MenuShell ===
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuShell.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Overlay ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Overlay.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Popover ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Popover.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::RecentChooserWidget ===
+Stage start      :   0.000
+
+    precomp lib/GTK/RecentChooserWidget.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.564
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.249
+    Stage mbc        :   0.008
+Stage parse      :   4.976
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Revealer ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Revealer.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ScaleButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ScaleButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Button.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Button.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ScrolledWindow ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ScrolledWindow.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::SearchBar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/SearchBar.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::SeparatorMenuItem ===
+Stage start      :   0.000
+
+    precomp lib/GTK/SeparatorMenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ShortcutsGroup ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ShortcutsGroup.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.282
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.297
+    Stage mbc        :   0.011
+Stage parse      :   4.711
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::ShortcutsSection ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ShortcutsSection.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.127
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.027
+    Stage mast       :   0.276
+    Stage mbc        :   0.012
+Stage parse      :   4.510
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::ShortcutsShortcut ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ShortcutsShortcut.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.205
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.043
+    Stage mast       :   0.320
+    Stage mbc        :   0.012
+Stage parse      :   4.647
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::StackSidebar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/StackSidebar.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::StackSwitcher ===
+Stage start      :   0.000
+
+    precomp lib/GTK/StackSwitcher.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/StackSwitcher.pm6 (GTK::StackSwitcher)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/StackSwitcher.pm6 (GTK::StackSwitcher):15
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/StackSwitcher.pm6 (GTK::StackSwitcher)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/StackSwitcher.pm6 (GTK::StackSwitcher):15
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Statusbar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Statusbar.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.130
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.028
+    Stage mast       :   0.279
+    Stage mbc        :   0.011
+Stage parse      :   4.564
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::ToggleButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ToggleButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Button.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Button.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ToolItem ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ToolItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ToolPalette ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ToolPalette.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToolItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ToolItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::TreeViewColumn ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TreeViewColumn.pm6
+    Stage start      :   0.000
+    Stage parse      :   2.409
+    Stage syntaxcheck:   0.000
+    Stage ast        :   0.000
+    Stage optimize   :   0.069
+    Stage mast       :   0.363
+    Stage mbc        :   0.013
+Stage parse      :   4.946
+Stage syntaxcheck:   0.000
+Stage ast        :   0.000
+Stage optimize   :   0.001
+Stage mast       :   0.004
+Stage mbc        :   0.001
+Stage moar       :   0.000
+ === GTK::Viewport ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Viewport.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::VolumeButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/VolumeButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ScaleButton.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Button.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Button.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ScaleButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Button.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Button.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Window ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ActionBar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ActionBar.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::AppButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/AppButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ComboBox.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ComboBox.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ApplicationWindow ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ApplicationWindow.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::AspectFrame ===
+Stage start      :   0.000
+
+    precomp lib/GTK/AspectFrame.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Frame.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Frame.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Assistant ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Assistant.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::CellRendererCombo ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CellRendererCombo.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ComboBox.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ComboBox.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::CheckButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CheckButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToggleButton.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Button.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Button.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ToggleButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Button.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Button.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::CheckMenuItem ===
+Stage start      :   0.000
+
+    precomp lib/GTK/CheckMenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Dialog ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Dialog::About ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/About.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Dialog.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Window.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Dialog::AppChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/AppChooser.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Dialog.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Window.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Dialog::ColorChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/ColorChooser.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Dialog.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Window.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Dialog::FileChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/FileChooser.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Dialog.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Window.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Dialog::FontChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/FontChooser.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Dialog.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Window.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Dialog::Message ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/Message.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Dialog.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Window.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Dialog::PageSetupUnix ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/PageSetupUnix.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Dialog.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Window.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Dialog::PrintUnix ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/PrintUnix.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Dialog.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Window.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Dialog::RecentChooser ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog/RecentChooser.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Dialog.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Window.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Dialog.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::FlowBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/FlowBox.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/FlowBoxChild.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/FlowBoxChild.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ListBox ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ListBox.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ListBoxRow.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ListBoxRow.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Menu ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Menu.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuShell.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/MenuItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuShell.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::MenuBar ===
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuBar.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuShell.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/MenuItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuShell.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::MenuButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Menu.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/MenuShell.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/MenuItem.pm6
+                Stage start      :   0.000
+                
+                    precomp lib/GTK/Bin.pm6
+                    Stage start      :   0.000
+                    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                        expecting any of:
+                            rw
+                            readonly
+                            box_target
+                            leading_docs
+                            trailing_docs
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/MenuItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuShell.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/MenuItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Menu.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuShell.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/MenuItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuShell.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Offscreen ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Offscreen.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Places ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Places.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ScrolledWindow.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ScrolledWindow.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::RadioButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/RadioButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/CheckButton.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/ToggleButton.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Button.pm6
+                Stage start      :   0.000
+                
+                    precomp lib/GTK/Bin.pm6
+                    Stage start      :   0.000
+                    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                        expecting any of:
+                            rw
+                            readonly
+                            box_target
+                            leading_docs
+                            trailing_docs
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Button.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToggleButton.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Button.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Button.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/CheckButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToggleButton.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Button.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Button.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ToggleButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Button.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Button.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::RadioMenuItem ===
+Stage start      :   0.000
+
+    precomp lib/GTK/RadioMenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/CheckMenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/MenuItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/CheckMenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::RecentChooserMenu ===
+Stage start      :   0.000
+
+    precomp lib/GTK/RecentChooserMenu.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Menu.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/MenuShell.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/MenuItem.pm6
+                Stage start      :   0.000
+                
+                    precomp lib/GTK/Bin.pm6
+                    Stage start      :   0.000
+                    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                        expecting any of:
+                            rw
+                            readonly
+                            box_target
+                            leading_docs
+                            trailing_docs
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/MenuItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuShell.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/MenuItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Menu.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuShell.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/MenuItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuShell.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::SeparatorToolItem ===
+Stage start      :   0.000
+
+    precomp lib/GTK/SeparatorToolItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToolItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ToolItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ShortcutsWindow ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ShortcutsWindow.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Stack ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Stack.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/StackSwitcher.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/StackSwitcher.pm6 (GTK::StackSwitcher)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/StackSwitcher.pm6 (GTK::StackSwitcher):15
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/StackSwitcher.pm6 (GTK::StackSwitcher)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/StackSwitcher.pm6 (GTK::StackSwitcher):15
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/StackSwitcher.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/StackSwitcher.pm6 (GTK::StackSwitcher)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/StackSwitcher.pm6 (GTK::StackSwitcher):15
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/StackSwitcher.pm6 (GTK::StackSwitcher)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/StackSwitcher.pm6 (GTK::StackSwitcher):15
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ToolButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ToolButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToolItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ToolItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::TreeView ===
+Stage start      :   0.000
+
+    precomp lib/GTK/TreeView.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/TreeIter.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/TreeIter.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/TreeIter.pm6 (GTK::TreeIter):12
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Utils::MenuBuilder ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Utils/MenuBuilder.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/CheckMenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/MenuItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/CheckMenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/MenuItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Application ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Application.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ApplicationWindow.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Window.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ApplicationWindow.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Window.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Window.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::MenuToolButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/MenuToolButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToolButton.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/ToolItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToolItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ToolButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToolItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ToolItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::ToggleToolButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/ToggleToolButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToolButton.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/ToolItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToolItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ToolButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToolItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ToolItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::RadioToolButton ===
+Stage start      :   0.000
+
+    precomp lib/GTK/RadioToolButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToggleToolButton.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/ToolButton.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/ToolItem.pm6
+                Stage start      :   0.000
+                
+                    precomp lib/GTK/Bin.pm6
+                    Stage start      :   0.000
+                    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                        expecting any of:
+                            rw
+                            readonly
+                            box_target
+                            leading_docs
+                            trailing_docs
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/ToolItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToolButton.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/ToolItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToolItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ToggleToolButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToolButton.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/ToolItem.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToolItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ToolButton.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ToolItem.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ToolItem.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK ===
+Stage start      :   0.000
+
+    precomp lib/GTK.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ActionBar.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ActionBar.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+ === GTK::Builder ===
+Stage start      :   0.000
+
+    precomp lib/GTK/Builder.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/ActionBar.pm6
+            Stage start      :   0.000
+            
+                precomp lib/GTK/Bin.pm6
+                Stage start      :   0.000
+                [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+                Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+                at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                    expecting any of:
+                        rw
+                        readonly
+                        box_target
+                        leading_docs
+                        trailing_docs
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ActionBar.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/ActionBar.pm6
+        Stage start      :   0.000
+        
+            precomp lib/GTK/Bin.pm6
+            Stage start      :   0.000
+            [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+            Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+            at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+                expecting any of:
+                    rw
+                    readonly
+                    box_target
+                    leading_docs
+                    trailing_docs
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/ActionBar.pm6
+    Stage start      :   0.000
+    
+        precomp lib/GTK/Bin.pm6
+        Stage start      :   0.000
+        [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+        Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+        at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+            expecting any of:
+                rw
+                readonly
+                box_target
+                leading_docs
+                trailing_docs
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+
+    precomp lib/GTK/Bin.pm6
+    Stage start      :   0.000
+    [31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+    Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+    at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+        expecting any of:
+            rw
+            readonly
+            box_target
+            leading_docs
+            trailing_docs
+Stage start      :   0.000
+[31m===[0mSORRY![31m===[0m Error while compiling /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin)
+Can't use unknown trait 'is' -> 'implementor' in an attribute declaration.
+at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/Bin.pm6 (GTK::Bin):14
+    expecting any of:
+        rw
+        readonly
+        box_target
+        leading_docs
+        trailing_docs
+
+real 3389.70
+user 4489.53
+sys 152.84


### PR DESCRIPTION
When calling `FlowBox.select-child` it throws the below error:

```
No such method 'resolve-selected-child' for invocant of type 'GTK::FlowBox'. Did you mean '!resolve-selected-child'?
  in method select_child at /home/hythm/dev/GTK/p6-GtkPlus/lib/GTK/FlowBox.pm6 (GTK::FlowBox) line 369
```
Test: After changing `.resolve-select-child` to `!resolve-select-child` select-child worked.
